### PR TITLE
Change net.peer.ip to net.peer.name, lower cardinality option

### DIFF
--- a/attributes.go
+++ b/attributes.go
@@ -16,7 +16,6 @@ package otelconnect
 
 import (
 	"net"
-	"net/netip"
 	"strconv"
 	"strings"
 
@@ -83,18 +82,12 @@ func requestAttributes(req *Request) []attribute.KeyValue {
 }
 
 func addressAttributes(address string) []attribute.KeyValue {
-	if addrPort, err := netip.ParseAddrPort(address); err == nil {
-		return []attribute.KeyValue{
-			semconv.NetPeerIPKey.String(addrPort.Addr().String()),
-			semconv.NetPeerPortKey.Int(int(addrPort.Port())),
-		}
-	}
 	if host, port, err := net.SplitHostPort(address); err == nil {
-		portint, err := strconv.Atoi(port)
-		if err != nil {
+		portInt, err := strconv.Atoi(port)
+		if err == nil {
 			return []attribute.KeyValue{
 				semconv.NetPeerNameKey.String(host),
-				semconv.NetPeerPortKey.Int(portint),
+				semconv.NetPeerPortKey.Int(portInt),
 			}
 		}
 	}

--- a/interceptor_test.go
+++ b/interceptor_test.go
@@ -1557,7 +1557,7 @@ func TestWithAttributeFilter(t *testing.T) {
 	}, spanRecorder.Ended())
 }
 
-func TestWithLowerCardinality(t *testing.T) {
+func TestWithoutServerPeerAttributes(t *testing.T) {
 	t.Parallel()
 	spanRecorder := tracetest.NewSpanRecorder()
 	traceProvider := trace.NewTracerProvider(trace.WithSpanProcessor(spanRecorder))

--- a/interceptor_test.go
+++ b/interceptor_test.go
@@ -1564,7 +1564,7 @@ func TestWithLowerCardinality(t *testing.T) {
 	pingClient, _, _ := startServer([]connect.HandlerOption{
 		WithTelemetry(
 			WithTracerProvider(traceProvider),
-			WithLowerServerCardinality(),
+			WithoutServerNetPeer(),
 		),
 	}, nil, happyPingServer())
 	stream := pingClient.CumSum(context.Background())

--- a/interceptor_test.go
+++ b/interceptor_test.go
@@ -1564,7 +1564,7 @@ func TestWithLowerCardinality(t *testing.T) {
 	pingClient, _, _ := startServer([]connect.HandlerOption{
 		WithTelemetry(
 			WithTracerProvider(traceProvider),
-			WithoutServerNetPeer(),
+			WithoutServerPeerAttributes(),
 		),
 	}, nil, happyPingServer())
 	stream := pingClient.CumSum(context.Background())

--- a/interceptor_test.go
+++ b/interceptor_test.go
@@ -113,7 +113,7 @@ func TestStreamingMetrics(t *testing.T) {
 							DataPoints: []metricdata.HistogramDataPoint{
 								{
 									Attributes: attribute.NewSet(
-										semconv.NetPeerIPKey.String(host),
+										semconv.NetPeerNameKey.String(host),
 										semconv.NetPeerPortKey.Int(port),
 										attribute.Key(rpcBufConnectStatusCode).String(successString),
 										semconv.RPCSystemKey.String(bufConnect),
@@ -136,7 +136,7 @@ func TestStreamingMetrics(t *testing.T) {
 							DataPoints: []metricdata.HistogramDataPoint{
 								{
 									Attributes: attribute.NewSet(
-										semconv.NetPeerIPKey.String(host),
+										semconv.NetPeerNameKey.String(host),
 										semconv.NetPeerPortKey.Int(port),
 										semconv.RPCSystemKey.String(bufConnect),
 										semconv.RPCServiceKey.String(pingv1connect.PingServiceName),
@@ -158,7 +158,7 @@ func TestStreamingMetrics(t *testing.T) {
 							DataPoints: []metricdata.HistogramDataPoint{
 								{
 									Attributes: attribute.NewSet(
-										semconv.NetPeerIPKey.String(host),
+										semconv.NetPeerNameKey.String(host),
 										semconv.NetPeerPortKey.Int(port),
 										semconv.RPCSystemKey.String(bufConnect),
 										semconv.RPCServiceKey.String(pingv1connect.PingServiceName),
@@ -180,7 +180,7 @@ func TestStreamingMetrics(t *testing.T) {
 							DataPoints: []metricdata.HistogramDataPoint{
 								{
 									Attributes: attribute.NewSet(
-										semconv.NetPeerIPKey.String(host),
+										semconv.NetPeerNameKey.String(host),
 										semconv.NetPeerPortKey.Int(port),
 										semconv.RPCSystemKey.String(bufConnect),
 										semconv.RPCServiceKey.String(pingv1connect.PingServiceName),
@@ -202,7 +202,7 @@ func TestStreamingMetrics(t *testing.T) {
 							DataPoints: []metricdata.HistogramDataPoint{
 								{
 									Attributes: attribute.NewSet(
-										semconv.NetPeerIPKey.String(host),
+										semconv.NetPeerNameKey.String(host),
 										semconv.NetPeerPortKey.Int(port),
 										semconv.RPCSystemKey.String(bufConnect),
 										semconv.RPCServiceKey.String(pingv1connect.PingServiceName),
@@ -276,7 +276,7 @@ func TestStreamingMetricsClient(t *testing.T) {
 							DataPoints: []metricdata.HistogramDataPoint{
 								{
 									Attributes: attribute.NewSet(
-										semconv.NetPeerIPKey.String(host),
+										semconv.NetPeerNameKey.String(host),
 										semconv.NetPeerPortKey.Int(port),
 										semconv.RPCSystemKey.String(bufConnect),
 										semconv.RPCServiceKey.String(pingv1connect.PingServiceName),
@@ -299,7 +299,7 @@ func TestStreamingMetricsClient(t *testing.T) {
 							DataPoints: []metricdata.HistogramDataPoint{
 								{
 									Attributes: attribute.NewSet(
-										semconv.NetPeerIPKey.String(host),
+										semconv.NetPeerNameKey.String(host),
 										semconv.NetPeerPortKey.Int(port),
 										semconv.RPCSystemKey.String(bufConnect),
 										semconv.RPCServiceKey.String(pingv1connect.PingServiceName),
@@ -321,7 +321,7 @@ func TestStreamingMetricsClient(t *testing.T) {
 							DataPoints: []metricdata.HistogramDataPoint{
 								{
 									Attributes: attribute.NewSet(
-										semconv.NetPeerIPKey.String(host),
+										semconv.NetPeerNameKey.String(host),
 										semconv.NetPeerPortKey.Int(port),
 										semconv.RPCSystemKey.String(bufConnect),
 										semconv.RPCServiceKey.String(pingv1connect.PingServiceName),
@@ -343,7 +343,7 @@ func TestStreamingMetricsClient(t *testing.T) {
 							DataPoints: []metricdata.HistogramDataPoint{
 								{
 									Attributes: attribute.NewSet(
-										semconv.NetPeerIPKey.String(host),
+										semconv.NetPeerNameKey.String(host),
 										semconv.NetPeerPortKey.Int(port),
 										semconv.RPCSystemKey.String(bufConnect),
 										semconv.RPCServiceKey.String(pingv1connect.PingServiceName),
@@ -365,7 +365,7 @@ func TestStreamingMetricsClient(t *testing.T) {
 							DataPoints: []metricdata.HistogramDataPoint{
 								{
 									Attributes: attribute.NewSet(
-										semconv.NetPeerIPKey.String(host),
+										semconv.NetPeerNameKey.String(host),
 										semconv.NetPeerPortKey.Int(port),
 										semconv.RPCSystemKey.String(bufConnect),
 										semconv.RPCServiceKey.String(pingv1connect.PingServiceName),
@@ -440,7 +440,7 @@ func TestStreamingMetricsClientFail(t *testing.T) {
 							DataPoints: []metricdata.HistogramDataPoint{
 								{
 									Attributes: attribute.NewSet(
-										semconv.NetPeerIPKey.String(host),
+										semconv.NetPeerNameKey.String(host),
 										semconv.NetPeerPortKey.Int(port),
 										semconv.RPCSystemKey.String(bufConnect),
 										semconv.RPCServiceKey.String(pingv1connect.PingServiceName),
@@ -463,7 +463,7 @@ func TestStreamingMetricsClientFail(t *testing.T) {
 							DataPoints: []metricdata.HistogramDataPoint{
 								{
 									Attributes: attribute.NewSet(
-										semconv.NetPeerIPKey.String(host),
+										semconv.NetPeerNameKey.String(host),
 										semconv.NetPeerPortKey.Int(port),
 										semconv.RPCSystemKey.String(bufConnect),
 										semconv.RPCServiceKey.String(pingv1connect.PingServiceName),
@@ -485,7 +485,7 @@ func TestStreamingMetricsClientFail(t *testing.T) {
 							DataPoints: []metricdata.HistogramDataPoint{
 								{
 									Attributes: attribute.NewSet(
-										semconv.NetPeerIPKey.String(host),
+										semconv.NetPeerNameKey.String(host),
 										semconv.NetPeerPortKey.Int(port),
 										semconv.RPCSystemKey.String(bufConnect),
 										semconv.RPCServiceKey.String(pingv1connect.PingServiceName),
@@ -498,7 +498,7 @@ func TestStreamingMetricsClientFail(t *testing.T) {
 								},
 								{
 									Attributes: attribute.NewSet(
-										semconv.NetPeerIPKey.String(host),
+										semconv.NetPeerNameKey.String(host),
 										semconv.NetPeerPortKey.Int(port),
 										attribute.Key(rpcBufConnectStatusCode).String("data_loss"),
 										semconv.RPCSystemKey.String(bufConnect),
@@ -521,7 +521,7 @@ func TestStreamingMetricsClientFail(t *testing.T) {
 							DataPoints: []metricdata.HistogramDataPoint{
 								{
 									Attributes: attribute.NewSet(
-										semconv.NetPeerIPKey.String(host),
+										semconv.NetPeerNameKey.String(host),
 										semconv.NetPeerPortKey.Int(port),
 										semconv.RPCSystemKey.String(bufConnect),
 										semconv.RPCServiceKey.String(pingv1connect.PingServiceName),
@@ -543,7 +543,7 @@ func TestStreamingMetricsClientFail(t *testing.T) {
 							DataPoints: []metricdata.HistogramDataPoint{
 								{
 									Attributes: attribute.NewSet(
-										semconv.NetPeerIPKey.String(host),
+										semconv.NetPeerNameKey.String(host),
 										semconv.NetPeerPortKey.Int(port),
 										semconv.RPCSystemKey.String(bufConnect),
 										semconv.RPCServiceKey.String(pingv1connect.PingServiceName),
@@ -556,7 +556,7 @@ func TestStreamingMetricsClientFail(t *testing.T) {
 								},
 								{
 									Attributes: attribute.NewSet(
-										semconv.NetPeerIPKey.String(host),
+										semconv.NetPeerNameKey.String(host),
 										semconv.NetPeerPortKey.Int(port),
 										semconv.RPCSystemKey.String(bufConnect),
 										semconv.RPCServiceKey.String(pingv1connect.PingServiceName),
@@ -631,7 +631,7 @@ func TestStreamingMetricsFail(t *testing.T) {
 							DataPoints: []metricdata.HistogramDataPoint{
 								{
 									Attributes: attribute.NewSet(
-										semconv.NetPeerIPKey.String(host),
+										semconv.NetPeerNameKey.String(host),
 										semconv.NetPeerPortKey.Int(port),
 										attribute.Key(rpcBufConnectStatusCode).String("data_loss"),
 										semconv.RPCSystemKey.String(bufConnect),
@@ -654,7 +654,7 @@ func TestStreamingMetricsFail(t *testing.T) {
 							DataPoints: []metricdata.HistogramDataPoint{
 								{
 									Attributes: attribute.NewSet(
-										semconv.NetPeerIPKey.String(host),
+										semconv.NetPeerNameKey.String(host),
 										semconv.NetPeerPortKey.Int(port),
 										semconv.RPCSystemKey.String(bufConnect),
 										semconv.RPCServiceKey.String(pingv1connect.PingServiceName),
@@ -676,7 +676,7 @@ func TestStreamingMetricsFail(t *testing.T) {
 							DataPoints: []metricdata.HistogramDataPoint{
 								{
 									Attributes: attribute.NewSet(
-										semconv.NetPeerIPKey.String(host),
+										semconv.NetPeerNameKey.String(host),
 										semconv.NetPeerPortKey.Int(port),
 										semconv.RPCSystemKey.String(bufConnect),
 										semconv.RPCServiceKey.String(pingv1connect.PingServiceName),
@@ -698,7 +698,7 @@ func TestStreamingMetricsFail(t *testing.T) {
 							DataPoints: []metricdata.HistogramDataPoint{
 								{
 									Attributes: attribute.NewSet(
-										semconv.NetPeerIPKey.String(host),
+										semconv.NetPeerNameKey.String(host),
 										semconv.NetPeerPortKey.Int(port),
 										semconv.RPCSystemKey.String(bufConnect),
 										semconv.RPCServiceKey.String(pingv1connect.PingServiceName),
@@ -720,7 +720,7 @@ func TestStreamingMetricsFail(t *testing.T) {
 							DataPoints: []metricdata.HistogramDataPoint{
 								{
 									Attributes: attribute.NewSet(
-										semconv.NetPeerIPKey.String(host),
+										semconv.NetPeerNameKey.String(host),
 										semconv.NetPeerPortKey.Int(port),
 										semconv.RPCSystemKey.String(bufConnect),
 										semconv.RPCServiceKey.String(pingv1connect.PingServiceName),
@@ -783,7 +783,7 @@ func TestMetrics(t *testing.T) {
 							DataPoints: []metricdata.HistogramDataPoint{
 								{
 									Attributes: attribute.NewSet(
-										semconv.NetPeerIPKey.String(host),
+										semconv.NetPeerNameKey.String(host),
 										semconv.NetPeerPortKey.Int(port),
 										attribute.Key(rpcBufConnectStatusCode).String(successString),
 										semconv.RPCMethodKey.String(PingMethod),
@@ -806,7 +806,7 @@ func TestMetrics(t *testing.T) {
 							DataPoints: []metricdata.HistogramDataPoint{
 								{
 									Attributes: attribute.NewSet(
-										semconv.NetPeerIPKey.String(host),
+										semconv.NetPeerNameKey.String(host),
 										semconv.NetPeerPortKey.Int(port),
 										attribute.Key(rpcBufConnectStatusCode).String(successString),
 										semconv.RPCMethodKey.String(PingMethod),
@@ -829,7 +829,7 @@ func TestMetrics(t *testing.T) {
 							DataPoints: []metricdata.HistogramDataPoint{
 								{
 									Attributes: attribute.NewSet(
-										semconv.NetPeerIPKey.String(host),
+										semconv.NetPeerNameKey.String(host),
 										semconv.NetPeerPortKey.Int(port),
 										attribute.Key(rpcBufConnectStatusCode).String(successString),
 										semconv.RPCMethodKey.String(PingMethod),
@@ -852,7 +852,7 @@ func TestMetrics(t *testing.T) {
 							DataPoints: []metricdata.HistogramDataPoint{
 								{
 									Attributes: attribute.NewSet(
-										semconv.NetPeerIPKey.String(host),
+										semconv.NetPeerNameKey.String(host),
 										semconv.NetPeerPortKey.Int(port),
 										attribute.Key(rpcBufConnectStatusCode).String(successString),
 										semconv.RPCMethodKey.String(PingMethod),
@@ -875,7 +875,7 @@ func TestMetrics(t *testing.T) {
 							DataPoints: []metricdata.HistogramDataPoint{
 								{
 									Attributes: attribute.NewSet(
-										semconv.NetPeerIPKey.String(host),
+										semconv.NetPeerNameKey.String(host),
 										semconv.NetPeerPortKey.Int(port),
 										attribute.Key(rpcBufConnectStatusCode).String(successString),
 										semconv.RPCMethodKey.String(PingMethod),
@@ -974,7 +974,7 @@ func TestClientSimple(t *testing.T) {
 				},
 			},
 			attrs: []attribute.KeyValue{
-				semconv.NetPeerIPKey.String(host),
+				semconv.NetPeerNameKey.String(host),
 				semconv.NetPeerPortKey.Int(port),
 				semconv.RPCSystemKey.String(bufConnect),
 				semconv.RPCServiceKey.String(pingv1connect.PingServiceName),
@@ -1021,7 +1021,7 @@ func TestHandlerFailCall(t *testing.T) {
 				},
 			},
 			attrs: []attribute.KeyValue{
-				semconv.NetPeerIPKey.String(host),
+				semconv.NetPeerNameKey.String(host),
 				semconv.NetPeerPortKey.Int(port),
 				semconv.RPCSystemKey.String(bufConnect),
 				semconv.RPCServiceKey.String(pingv1connect.PingServiceName),
@@ -1071,7 +1071,7 @@ func TestClientHandlerOpts(t *testing.T) {
 				},
 			},
 			attrs: []attribute.KeyValue{
-				semconv.NetPeerIPKey.String(host),
+				semconv.NetPeerNameKey.String(host),
 				semconv.NetPeerPortKey.Int(port),
 				semconv.RPCSystemKey.String(bufConnect),
 				semconv.RPCServiceKey.String(pingv1connect.PingServiceName),
@@ -1143,7 +1143,7 @@ func TestFilterHeader(t *testing.T) {
 				},
 			},
 			attrs: []attribute.KeyValue{
-				semconv.NetPeerIPKey.String(host),
+				semconv.NetPeerNameKey.String(host),
 				semconv.NetPeerPortKey.Int(port),
 				semconv.RPCSystemKey.String(bufConnect),
 				semconv.RPCServiceKey.String(pingv1connect.PingServiceName),
@@ -1190,7 +1190,7 @@ func TestInterceptors(t *testing.T) {
 				},
 			},
 			attrs: []attribute.KeyValue{
-				semconv.NetPeerIPKey.String(host),
+				semconv.NetPeerNameKey.String(host),
 				semconv.NetPeerPortKey.Int(port),
 				semconv.RPCSystemKey.String(bufConnect),
 				semconv.RPCServiceKey.String(pingv1connect.PingServiceName),
@@ -1219,7 +1219,7 @@ func TestInterceptors(t *testing.T) {
 				},
 			},
 			attrs: []attribute.KeyValue{
-				semconv.NetPeerIPKey.String(host),
+				semconv.NetPeerNameKey.String(host),
 				semconv.NetPeerPortKey.Int(port),
 				semconv.RPCSystemKey.String(bufConnect),
 				semconv.RPCServiceKey.String(pingv1connect.PingServiceName),
@@ -1443,7 +1443,7 @@ func TestStreamingHandlerTracing(t *testing.T) {
 				},
 			},
 			attrs: []attribute.KeyValue{
-				semconv.NetPeerIPKey.String(host),
+				semconv.NetPeerNameKey.String(host),
 				semconv.NetPeerPortKey.Int(port),
 				semconv.RPCSystemKey.String(bufConnect),
 				semconv.RPCServiceKey.String(pingv1connect.PingServiceName),
@@ -1490,7 +1490,7 @@ func TestStreamingClientTracing(t *testing.T) {
 				},
 			},
 			attrs: []attribute.KeyValue{
-				semconv.NetPeerIPKey.String(host),
+				semconv.NetPeerNameKey.String(host),
 				semconv.NetPeerPortKey.Int(port),
 				semconv.RPCSystemKey.String(bufConnect),
 				semconv.RPCServiceKey.String(pingv1connect.PingServiceName),
@@ -1547,7 +1547,7 @@ func TestWithAttributeFilter(t *testing.T) {
 				},
 			},
 			attrs: []attribute.KeyValue{
-				semconv.NetPeerIPKey.String(host),
+				semconv.NetPeerNameKey.String(host),
 				semconv.NetPeerPortKey.Int(port),
 				semconv.RPCSystemKey.String(bufConnect),
 				semconv.RPCMethodKey.String(CumSumMethod),

--- a/option.go
+++ b/option.go
@@ -84,10 +84,13 @@ func (o *withLowerServerCardinality) apply(c *config) {
 		if request.Spec.IsClient {
 			return true
 		}
-		if value.Key != semconv.NetPeerPortKey && value.Key != semconv.NetPeerNameKey {
-			return true
+		if value.Key == semconv.NetPeerPortKey {
+			return false
 		}
-		return false
+		if value.Key == semconv.NetPeerNameKey {
+			return false
+		}
+		return true
 	}
 }
 

--- a/option.go
+++ b/option.go
@@ -17,8 +17,10 @@ package otelconnect
 import (
 	"context"
 
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/propagation"
+	semconv "go.opentelemetry.io/otel/semconv/v1.12.0"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -67,6 +69,26 @@ func WithoutMetrics() Option {
 // WithAttributeFilter sets the attribute filter for all metrics and trace attributes.
 func WithAttributeFilter(filter AttributeFilter) Option {
 	return &attributeFilterOption{filterAttribute: filter}
+}
+
+// WithLowerServerCardinality removes net.peer.port and net.peer.name attributes from server trace and span attributes.
+// This is recommended to use as net.peer server attributes have high cardinality.
+func WithLowerServerCardinality() Option {
+	return &withLowerServerCardinality{}
+}
+
+type withLowerServerCardinality struct{}
+
+func (o *withLowerServerCardinality) apply(c *config) {
+	c.filterAttribute = func(request *Request, value attribute.KeyValue) bool {
+		if request.Spec.IsClient {
+			return true
+		}
+		if value.Key != semconv.NetPeerPortKey && value.Key != semconv.NetPeerNameKey {
+			return true
+		}
+		return false
+	}
 }
 
 type attributeFilterOption struct {

--- a/option.go
+++ b/option.go
@@ -71,15 +71,15 @@ func WithAttributeFilter(filter AttributeFilter) Option {
 	return &attributeFilterOption{filterAttribute: filter}
 }
 
-// WithLowerServerCardinality removes net.peer.port and net.peer.name attributes from server trace and span attributes.
+// WithoutServerNetPeer removes net.peer.port and net.peer.name attributes from server trace and span attributes.
 // This is recommended to use as net.peer server attributes have high cardinality.
-func WithLowerServerCardinality() Option {
-	return &withLowerServerCardinality{}
+func WithoutServerNetPeer() Option {
+	return &withoutServerNetPeerOption{}
 }
 
-type withLowerServerCardinality struct{}
+type withoutServerNetPeerOption struct{}
 
-func (o *withLowerServerCardinality) apply(c *config) {
+func (o *withoutServerNetPeerOption) apply(c *config) {
 	c.filterAttribute = func(request *Request, value attribute.KeyValue) bool {
 		if request.Spec.IsClient {
 			return true

--- a/option.go
+++ b/option.go
@@ -71,16 +71,10 @@ func WithAttributeFilter(filter AttributeFilter) Option {
 	return &attributeFilterOption{filterAttribute: filter}
 }
 
-// WithoutServerNetPeer removes net.peer.port and net.peer.name attributes from server trace and span attributes.
+// WithoutServerPeerAttributes removes net.peer.port and net.peer.name attributes from server trace and span attributes.
 // This is recommended to use as net.peer server attributes have high cardinality.
-func WithoutServerNetPeer() Option {
-	return &withoutServerNetPeerOption{}
-}
-
-type withoutServerNetPeerOption struct{}
-
-func (o *withoutServerNetPeerOption) apply(c *config) {
-	c.filterAttribute = func(request *Request, value attribute.KeyValue) bool {
+func WithoutServerPeerAttributes() Option {
+	return WithAttributeFilter(func(request *Request, value attribute.KeyValue) bool {
 		if request.Spec.IsClient {
 			return true
 		}
@@ -91,7 +85,7 @@ func (o *withoutServerNetPeerOption) apply(c *config) {
 			return false
 		}
 		return true
-	}
+	})
 }
 
 type attributeFilterOption struct {


### PR DESCRIPTION
This removes all references to `net.peer.ip` addresses and replaces it with `net.peer.name` as is required for the opentelemetry specification. 



> net.peer.name | string | RPC server host name. [3] | example.com | Required
> -- | -- | -- | -- | --


> Additional attribute requirements: At least one of the following sets of attributes is required:

> [net.sock.peer.addr](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/span-general.md)
[net.peer.name](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/span-general.md)


Also notably this can also be set to up addresses:
> When host component is an IP address, instrumentations SHOULD NOT do a reverse proxy lookup to obtain DNS name and SHOULD set net.peer.name to the IP address provided in the host component.


There was also an issue in the logic that wasn't adding `NetPeerPortKey` correctly, that's now been fixed.

Related: https://github.com/bufbuild/connect-opentelemetry-go/issues/48