### PR TITLE
Fix span status

### DIFF
--- a/interceptor.go
+++ b/interceptor.go
@@ -290,7 +290,7 @@ func protocolToSemConv(protocol string) string {
 
 func spanStatus(err error) (codes.Code, string) {
 	if err == nil {
-		return codes.Ok, ""
+		return codes.Unset, ""
 	}
 	if connectErr := new(connect.Error); errors.As(err, &connectErr) {
 		return codes.Error, connectErr.Message()

--- a/interceptor_test.go
+++ b/interceptor_test.go
@@ -1686,8 +1686,6 @@ func TestStreamingSpanStatus(t *testing.T) {
 	handlerTraceProvider := trace.NewTracerProvider(trace.WithSpanProcessor(handlerSpanRecorder))
 	clientSpanRecorder := tracetest.NewSpanRecorder()
 	clientTraceProvider := trace.NewTracerProvider(trace.WithSpanProcessor(clientSpanRecorder))
-	ctx, rootSpan := trace.NewTracerProvider().Tracer("test").Start(context.Background(), "test")
-	defer rootSpan.End()
 	client, _, _ := startServer(
 		[]connect.HandlerOption{WithTelemetry(
 			WithPropagator(propagator),
@@ -1698,7 +1696,7 @@ func TestStreamingSpanStatus(t *testing.T) {
 				WithTracerProvider(clientTraceProvider),
 			),
 		}, failPingServer())
-	stream := client.CumSum(ctx)
+	stream := client.CumSum(context.Background())
 	assert.NoError(t, stream.Send(&pingv1.CumSumRequest{Number: 1}))
 	_, err := stream.Receive()
 	assert.NoError(t, err)


### PR DESCRIPTION
- Only set SpanStatus when errors are non nil
- Leave SpanStatus unset for all non error scenarios
- Add test for Streaming 
- Update old tests to check SpanStatus

Fixes: https://github.com/bufbuild/connect-opentelemetry-go/issues/51