### PR TITLE
Add metadata attributes

### DIFF
--- a/attributes.go
+++ b/attributes.go
@@ -134,12 +134,14 @@ func formatHeaderAttributeKey(key string) string {
 }
 
 func formatHeaderAttributeValue(val []string) string {
-	var stringVal string
+	var builder strings.Builder
+	builder.WriteString("[")
 	for i, elem := range val {
-		stringVal += fmt.Sprintf(`"%s"`, elem)
+		builder.WriteString(fmt.Sprintf(`"%s"`, elem))
 		if i != len(val)-1 {
-			stringVal += ", "
+			builder.WriteString(", ")
 		}
 	}
-	return "[" + stringVal + "]"
+	builder.WriteString("]")
+	return builder.String()
 }

--- a/attributes.go
+++ b/attributes.go
@@ -116,11 +116,11 @@ func statusCodeAttribute(protocol string, serverErr error) (attribute.KeyValue, 
 }
 
 func headerAttributes(protocol, eventType string, metadata http.Header, allowedKeys []string) []attribute.KeyValue {
-	var attributes []attribute.KeyValue
+	attributes := make([]attribute.KeyValue, 0, len(allowedKeys))
 	for _, allowedKey := range allowedKeys {
 		if val, ok := metadata[allowedKey]; ok {
 			keyValue := attribute.StringSlice(
-				formatHeaderAttributes(protocol, eventType, formatHeaderAttributeKey(allowedKey)),
+				formatHeaderAttributeKey(protocol, eventType, allowedKey),
 				val,
 			)
 			attributes = append(attributes, keyValue)
@@ -129,10 +129,9 @@ func headerAttributes(protocol, eventType string, metadata http.Header, allowedK
 	return attributes
 }
 
-func formatHeaderAttributes(protocol, eventType, key string) string {
+// formatHeaderAttributeKey formats header attributes as suggested by the OpenTelemetry specification:
+// https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/rpc.md#grpc-request-and-response-metadata
+func formatHeaderAttributeKey(protocol, eventType, key string) string {
+	key = strings.ReplaceAll(strings.ToLower(key), "-", "_")
 	return fmt.Sprintf("rpc.%s.%s.metadata.%s", protocol, eventType, key)
-}
-
-func formatHeaderAttributeKey(key string) string {
-	return strings.ReplaceAll(strings.ToLower(key), "-", "_")
 }

--- a/attributes.go
+++ b/attributes.go
@@ -115,9 +115,9 @@ func headerAttributes(protocol, eventType string, metadata http.Header, allowedK
 	var attributes []attribute.KeyValue
 	for _, allowedKey := range allowedKeys {
 		if val, ok := metadata[allowedKey]; ok {
-			keyValue := attribute.String(
+			keyValue := attribute.StringSlice(
 				formatHeaderAttributes(protocol, eventType, formatHeaderAttributeKey(allowedKey)),
-				formatHeaderAttributeValue(val),
+				val,
 			)
 			attributes = append(attributes, keyValue)
 		}
@@ -131,17 +131,4 @@ func formatHeaderAttributes(protocol, eventType, key string) string {
 
 func formatHeaderAttributeKey(key string) string {
 	return strings.ReplaceAll(strings.ToLower(key), "-", "_")
-}
-
-func formatHeaderAttributeValue(val []string) string {
-	var builder strings.Builder
-	builder.WriteString("[")
-	for i, elem := range val {
-		builder.WriteString(fmt.Sprintf(`"%s"`, elem))
-		if i != len(val)-1 {
-			builder.WriteString(", ")
-		}
-	}
-	builder.WriteString("]")
-	return builder.String()
 }

--- a/instruments.go
+++ b/instruments.go
@@ -34,6 +34,8 @@ const (
 	messageKey         = "message"
 	serverKey          = "server"
 	clientKey          = "client"
+	requestKey         = "request"
+	responseKey        = "response"
 )
 
 type instruments struct {

--- a/interceptor_test.go
+++ b/interceptor_test.go
@@ -1170,18 +1170,21 @@ func TestHeaderAttribute(t *testing.T) {
 	attributeCumsumReq := attribute.StringSlice(cumsumReqKey, attributeValue)
 	attributePingRes := attribute.StringSlice(pingResKey, attributeValueLong)
 	attributeCumsumRes := attribute.StringSlice(cumsumResKey, attributeValue)
-	metadataOption := WithTraceMetadataAttributes([]string{pingReq, cumsumReq}, []string{pingRes, cumsumRes})
+	requestHeaderOption := WithTraceRequestHeader(pingReq, cumsumReq)
+	responseHeaderOption := WithTraceResponseHeader(pingRes, cumsumRes)
 	client, _, _ := startServer(
 		[]connect.HandlerOption{
 			connect.WithInterceptors(NewInterceptor(
 				WithPropagator(propagator),
 				WithTracerProvider(handlerTraceProvider),
-				metadataOption,
+				requestHeaderOption,
+				responseHeaderOption,
 			))}, []connect.ClientOption{
 			connect.WithInterceptors(NewInterceptor(
 				WithPropagator(propagator),
 				WithTracerProvider(clientTraceProvider),
-				metadataOption,
+				requestHeaderOption,
+				responseHeaderOption,
 			)),
 		}, &pluggablePingServer{
 			ping: func(ctx context.Context, req *connect.Request[pingv1.PingRequest]) (*connect.Response[pingv1.PingResponse], error) {

--- a/interceptor_test.go
+++ b/interceptor_test.go
@@ -1159,10 +1159,10 @@ func TestHeaderAttribute(t *testing.T) {
 	clientSpanRecorder := tracetest.NewSpanRecorder()
 	clientTraceProvider := trace.NewTracerProvider(trace.WithSpanProcessor(clientSpanRecorder))
 	pingReq, pingRes, cumsumReq, cumsumRes := "pingReq", "pingRes", "cumsumReq", "cumsumRes"
-	pingReqKey := "rpc.buf_connect.request.metadata.pingreq"
-	pingResKey := "rpc.buf_connect.response.metadata.pingres"
-	cumsumReqKey := "rpc.buf_connect.request.metadata.cumsumreq"
-	cumsumResKey := "rpc.buf_connect.response.metadata.cumsumres"
+	pingReqKey := "rpc.connect_rpc.request.metadata.pingreq"
+	pingResKey := "rpc.connect_rpc.response.metadata.pingres"
+	cumsumReqKey := "rpc.connect_rpc.request.metadata.cumsumreq"
+	cumsumResKey := "rpc.connect_rpc.response.metadata.cumsumres"
 	value := "value"
 	attributeValue := []string{value}
 	attributeValueLong := []string{value, value}

--- a/interceptor_test.go
+++ b/interceptor_test.go
@@ -1182,16 +1182,17 @@ func TestHeaderAttribute(t *testing.T) {
 	attributeCumsumRes := attribute.String(cumsumResKey, attributeValue)
 	metadataOption := WithTraceMetadataAttributes([]string{pingReq, cumsumReq}, []string{pingRes, cumsumRes})
 	client, _, _ := startServer(
-		[]connect.HandlerOption{WithTelemetry(
-			WithPropagator(propagator),
-			WithTracerProvider(handlerTraceProvider),
-			metadataOption,
-		)}, []connect.ClientOption{
-			WithTelemetry(
+		[]connect.HandlerOption{
+			connect.WithInterceptors(NewInterceptor(
+				WithPropagator(propagator),
+				WithTracerProvider(handlerTraceProvider),
+				metadataOption,
+			))}, []connect.ClientOption{
+			connect.WithInterceptors(NewInterceptor(
 				WithPropagator(propagator),
 				WithTracerProvider(clientTraceProvider),
 				metadataOption,
-			),
+			)),
 		}, &pluggablePingServer{
 			ping: func(ctx context.Context, req *connect.Request[pingv1.PingRequest]) (*connect.Response[pingv1.PingResponse], error) {
 				response := connect.NewResponse(&pingv1.PingResponse{})

--- a/interceptor_test.go
+++ b/interceptor_test.go
@@ -1511,6 +1511,7 @@ func TestStreamingPropagation(t *testing.T) {
 			)),
 		}, happyPingServer())
 	stream := client.CumSum(ctx)
+	assert.NoError(t, stream.Send(nil))
 	assert.NoError(t, stream.CloseRequest())
 	assert.NoError(t, stream.CloseResponse())
 	assert.Equal(t, len(handlerSpanRecorder.Ended()), 1)
@@ -1538,6 +1539,7 @@ func TestWithUntrustedRemoteStreaming(t *testing.T) {
 			)),
 		}, happyPingServer())
 	stream := client.CumSum(ctx)
+	assert.NoError(t, stream.Send(nil))
 	assert.NoError(t, stream.CloseRequest())
 	assert.NoError(t, stream.CloseResponse())
 	assert.Equal(t, len(handlerSpanRecorder.Ended()), 1)
@@ -1560,6 +1562,7 @@ func TestStreamingClientPropagation(t *testing.T) {
 	}, &pluggablePingServer{cumSum: assertTraceParent},
 	)
 	stream := client.CumSum(context.Background())
+	assert.NoError(t, stream.Send(nil))
 	assert.NoError(t, stream.CloseRequest())
 	resp, err := stream.Receive()
 	assert.NoError(t, stream.CloseResponse())

--- a/interceptor_test.go
+++ b/interceptor_test.go
@@ -1174,12 +1174,12 @@ func TestHeaderAttribute(t *testing.T) {
 	cumsumReqKey := "rpc.buf_connect.request.metadata.cumsumreq"
 	cumsumResKey := "rpc.buf_connect.response.metadata.cumsumres"
 	value := "value"
-	attributeValue := `["value"]`
-	attributeValueLong := `["value", "value"]`
-	attributePingReq := attribute.String(pingReqKey, attributeValue)
-	attributeCumsumReq := attribute.String(cumsumReqKey, attributeValue)
-	attributePingRes := attribute.String(pingResKey, attributeValueLong)
-	attributeCumsumRes := attribute.String(cumsumResKey, attributeValue)
+	attributeValue := []string{value}
+	attributeValueLong := []string{value, value}
+	attributePingReq := attribute.StringSlice(pingReqKey, attributeValue)
+	attributeCumsumReq := attribute.StringSlice(cumsumReqKey, attributeValue)
+	attributePingRes := attribute.StringSlice(pingResKey, attributeValueLong)
+	attributeCumsumRes := attribute.StringSlice(cumsumResKey, attributeValue)
 	metadataOption := WithTraceMetadataAttributes([]string{pingReq, cumsumReq}, []string{pingRes, cumsumRes})
 	client, _, _ := startServer(
 		[]connect.HandlerOption{

--- a/option.go
+++ b/option.go
@@ -16,6 +16,7 @@ package otelconnect
 
 import (
 	"context"
+	"net/http"
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
@@ -96,6 +97,15 @@ func WithTrustRemote() Option {
 	return &trustRemoteOption{}
 }
 
+// WithTraceMetadataAttributes enables metadata attributes for the metadata keys provided.
+// Attributes will be added as Trace attributes only.
+func WithTraceMetadataAttributes(requestKeys, responseKeys []string) Option {
+	return &traceMetadataAttributeOption{
+		metadataReqKeys: requestKeys,
+		metadataResKeys: responseKeys,
+	}
+}
+
 type attributeFilterOption struct {
 	filterAttribute AttributeFilter
 }
@@ -154,4 +164,18 @@ type trustRemoteOption struct{}
 
 func (o *trustRemoteOption) apply(c *config) {
 	c.trustRemote = true
+}
+
+type traceMetadataAttributeOption struct {
+	metadataReqKeys []string
+	metadataResKeys []string
+}
+
+func (o *traceMetadataAttributeOption) apply(c *config) {
+	for _, key := range o.metadataReqKeys {
+		c.metadataReqKeys = append(c.metadataReqKeys, http.CanonicalHeaderKey(key))
+	}
+	for _, key := range o.metadataResKeys {
+		c.metadataResKeys = append(c.metadataResKeys, http.CanonicalHeaderKey(key))
+	}
 }

--- a/option.go
+++ b/option.go
@@ -97,12 +97,19 @@ func WithTrustRemote() Option {
 	return &trustRemoteOption{}
 }
 
-// WithTraceMetadataAttributes enables metadata attributes for the metadata keys provided.
+// WithTraceRequestHeader enables header attributes for the request header keys provided.
 // Attributes will be added as Trace attributes only.
-func WithTraceMetadataAttributes(requestKeys, responseKeys []string) Option {
-	return &traceMetadataAttributeOption{
-		metadataReqKeys: requestKeys,
-		metadataResKeys: responseKeys,
+func WithTraceRequestHeader(keys ...string) Option {
+	return &traceRequestHeaderOption{
+		keys: keys,
+	}
+}
+
+// WithTraceResponseHeader enables header attributes for the response header keys provided.
+// Attributes will be added as Trace attributes only.
+func WithTraceResponseHeader(keys ...string) Option {
+	return &traceResponseHeaderOption{
+		keys: keys,
 	}
 }
 
@@ -166,16 +173,22 @@ func (o *trustRemoteOption) apply(c *config) {
 	c.trustRemote = true
 }
 
-type traceMetadataAttributeOption struct {
-	metadataReqKeys []string
-	metadataResKeys []string
+type traceRequestHeaderOption struct {
+	keys []string
 }
 
-func (o *traceMetadataAttributeOption) apply(c *config) {
-	for _, key := range o.metadataReqKeys {
-		c.metadataReqKeys = append(c.metadataReqKeys, http.CanonicalHeaderKey(key))
+func (o *traceRequestHeaderOption) apply(c *config) {
+	for _, key := range o.keys {
+		c.requestHeaderKeys = append(c.requestHeaderKeys, http.CanonicalHeaderKey(key))
 	}
-	for _, key := range o.metadataResKeys {
-		c.metadataResKeys = append(c.metadataResKeys, http.CanonicalHeaderKey(key))
+}
+
+type traceResponseHeaderOption struct {
+	keys []string
+}
+
+func (o *traceResponseHeaderOption) apply(c *config) {
+	for _, key := range o.keys {
+		c.responseHeaderKeys = append(c.responseHeaderKeys, http.CanonicalHeaderKey(key))
 	}
 }

--- a/otelconnect.go
+++ b/otelconnect.go
@@ -50,6 +50,8 @@ type config struct {
 	propagator      propagation.TextMapPropagator
 	now             func() time.Time
 	trustRemote     bool
+	metadataReqKeys []string
+	metadataResKeys []string
 }
 
 // WithTelemetry returns a [connect.Option] that adds OpenTelemetry metrics

--- a/otelconnect.go
+++ b/otelconnect.go
@@ -46,13 +46,13 @@ type Request struct {
 }
 
 type config struct {
-	filter          func(context.Context, *Request) bool
-	filterAttribute AttributeFilter
-	meter           metric.Meter
-	tracer          trace.Tracer
-	propagator      propagation.TextMapPropagator
-	now             func() time.Time
-	trustRemote     bool
-	metadataReqKeys []string
-	metadataResKeys []string
+	filter             func(context.Context, *Request) bool
+	filterAttribute    AttributeFilter
+	meter              metric.Meter
+	tracer             trace.Tracer
+	propagator         propagation.TextMapPropagator
+	now                func() time.Time
+	trustRemote        bool
+	requestHeaderKeys  []string
+	responseHeaderKeys []string
 }


### PR DESCRIPTION
Adds metadata attributes to all types. 
Metadata attributes are _only_ defined in the spec for trace span attributes.
The ones defined are:
- `rpc.<protocol>.request.metadata.<normalised key>`
- `rpc.<protocol>.response.metadata.<normalised key>`
Where; 
- The `<normalised key>` are specified via the `WithTraceMetadataAttributes(requestKeys, responseKeys []string)` Option. 
- protocol is one of `grpc`, `grpc_web` or `buf_connect` 
- "normalised"  is `<key> being the normalized gRPC Metadata key (lowercase, with - characters replaced by _), the value being the metadata values.` as per the [spec](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/rpc.md#grpc-request-and-response-metadata). This is implemented [here](https://github.com/bufbuild/connect-opentelemetry-go/pull/59/files#r1072737068)
- The value formatting is in the format `rpc.request.metadata.my_custom_metadata_attribute=["1.2.3.4", "1.2.3.5"]`, which is implemented [here](https://github.com/bufbuild/connect-opentelemetry-go/pull/59/files#r1072738606)

Closes: https://github.com/bufbuild/connect-opentelemetry-go/issues/52