### PR TITLE
Remove WithTelemetry option in favor of connect.WithInterceptors(otelconnect.NewInterceptor())

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,14 +39,14 @@ import (
 func main() {
   mux := http.NewServeMux()
 
-  // otelconnect.WithTelemetry adds tracing and metrics to both clients and
+  // otelconnect.New provides an interceptor that adds tracing and metrics to both clients and
   // handlers. By default, it uses OpenTelemetry's global TracerProvider and
   // MeterProvider, which you can configure by following the OpenTelemetry
   // documentation. If you'd prefer to avoid globals, use
   // otelconnect.WithTracerProvider and otelconnect.WithMeterProvider.
   mux.Handle(pingv1connect.NewPingServiceHandler(
     &pingv1connect.UnimplementedPingServiceHandler{},
-    otelconnect.WithTelemetry(),
+	  connect.WithInterceptors(otelconnect.New(),
   ))
 
   http.ListenAndServe("localhost:8080", mux)
@@ -56,7 +56,7 @@ func makeRequest() {
   client := pingv1connect.NewPingServiceClient(
     http.DefaultClient,
     "http://localhost:8080",
-    otelconnect.WithTelemetry(),
+    connect.WithInterceptors(otelconnect.New(),
   )
   resp, err := client.Ping(
     context.Background(),

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ func main() {
   // otelconnect.WithTracerProvider and otelconnect.WithMeterProvider.
   mux.Handle(pingv1connect.NewPingServiceHandler(
     &pingv1connect.UnimplementedPingServiceHandler{},
-	  connect.WithInterceptors(otelconnect.New(),
+	  connect.WithInterceptors(otelconnect.New()),
   ))
 
   http.ListenAndServe("localhost:8080", mux)
@@ -56,7 +56,7 @@ func makeRequest() {
   client := pingv1connect.NewPingServiceClient(
     http.DefaultClient,
     "http://localhost:8080",
-    connect.WithInterceptors(otelconnect.New(),
+    connect.WithInterceptors(otelconnect.New()),
   )
   resp, err := client.Ping(
     context.Background(),

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ func main() {
   // otelconnect.WithTracerProvider and otelconnect.WithMeterProvider.
   mux.Handle(pingv1connect.NewPingServiceHandler(
     &pingv1connect.UnimplementedPingServiceHandler{},
-	  connect.WithInterceptors(otelconnect.New()),
+	  connect.WithInterceptors(otelconnect.NewInterceptor()),
   ))
 
   http.ListenAndServe("localhost:8080", mux)
@@ -56,7 +56,7 @@ func makeRequest() {
   client := pingv1connect.NewPingServiceClient(
     http.DefaultClient,
     "http://localhost:8080",
-    connect.WithInterceptors(otelconnect.New()),
+    connect.WithInterceptors(otelconnect.NewInterceptor()),
   )
   resp, err := client.Ping(
     context.Background(),

--- a/bench_test.go
+++ b/bench_test.go
@@ -36,19 +36,19 @@ func BenchmarkStreamingServerNoOptions(b *testing.B) {
 }
 
 func BenchmarkStreamingServerClientOption(b *testing.B) {
-	testStreaming(b, []connect.HandlerOption{WithTelemetry()}, []connect.ClientOption{WithTelemetry()})
+	testStreaming(b, []connect.HandlerOption{connect.WithInterceptors(New())}, []connect.ClientOption{connect.WithInterceptors(New())})
 }
 
 func BenchmarkStreamingServerOption(b *testing.B) {
-	testStreaming(b, []connect.HandlerOption{WithTelemetry()}, []connect.ClientOption{})
+	testStreaming(b, []connect.HandlerOption{connect.WithInterceptors(New())}, []connect.ClientOption{})
 }
 
 func BenchmarkStreamingClientOption(b *testing.B) {
-	testStreaming(b, []connect.HandlerOption{}, []connect.ClientOption{WithTelemetry()})
+	testStreaming(b, []connect.HandlerOption{}, []connect.ClientOption{connect.WithInterceptors(New())})
 }
 
 func BenchmarkUnaryOtel(b *testing.B) {
-	benchUnary(b, []connect.HandlerOption{WithTelemetry()}, []connect.ClientOption{WithTelemetry()})
+	benchUnary(b, []connect.HandlerOption{connect.WithInterceptors(New())}, []connect.ClientOption{connect.WithInterceptors(New())})
 }
 
 func BenchmarkUnary(b *testing.B) {

--- a/bench_test.go
+++ b/bench_test.go
@@ -36,19 +36,19 @@ func BenchmarkStreamingServerNoOptions(b *testing.B) {
 }
 
 func BenchmarkStreamingServerClientOption(b *testing.B) {
-	testStreaming(b, []connect.HandlerOption{connect.WithInterceptors(New())}, []connect.ClientOption{connect.WithInterceptors(New())})
+	testStreaming(b, []connect.HandlerOption{connect.WithInterceptors(NewInterceptor())}, []connect.ClientOption{connect.WithInterceptors(NewInterceptor())})
 }
 
 func BenchmarkStreamingServerOption(b *testing.B) {
-	testStreaming(b, []connect.HandlerOption{connect.WithInterceptors(New())}, []connect.ClientOption{})
+	testStreaming(b, []connect.HandlerOption{connect.WithInterceptors(NewInterceptor())}, []connect.ClientOption{})
 }
 
 func BenchmarkStreamingClientOption(b *testing.B) {
-	testStreaming(b, []connect.HandlerOption{}, []connect.ClientOption{connect.WithInterceptors(New())})
+	testStreaming(b, []connect.HandlerOption{}, []connect.ClientOption{connect.WithInterceptors(NewInterceptor())})
 }
 
 func BenchmarkUnaryOtel(b *testing.B) {
-	benchUnary(b, []connect.HandlerOption{connect.WithInterceptors(New())}, []connect.ClientOption{connect.WithInterceptors(New())})
+	benchUnary(b, []connect.HandlerOption{connect.WithInterceptors(NewInterceptor())}, []connect.ClientOption{connect.WithInterceptors(NewInterceptor())})
 }
 
 func BenchmarkUnary(b *testing.B) {

--- a/interceptor.go
+++ b/interceptor.go
@@ -18,28 +18,53 @@ import (
 	"context"
 	"errors"
 	"strings"
+	"time"
 
 	"github.com/bufbuild/connect-go"
+	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/metric/global"
 	"go.opentelemetry.io/otel/propagation"
 	semconv "go.opentelemetry.io/otel/semconv/v1.12.0"
 	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/protobuf/proto"
 )
 
-type interceptor struct {
+// Interceptor implements [connect.Interceptor] that adds
+// OpenTelemetry metrics and tracing to connect handlers and clients.
+type Interceptor struct {
 	config             config
 	clientInstruments  instruments
 	handlerInstruments instruments
 }
 
-func newInterceptor(cfg config) *interceptor {
-	return &interceptor{
+var _ connect.Interceptor = &Interceptor{}
+
+// NewInterceptor constructs and returns an Interceptor which implements [connect.Interceptor]
+// that adds OpenTelemetry metrics and tracing to Connect handlers and clients.
+func NewInterceptor(options ...Option) *Interceptor {
+	cfg := config{
+		now: time.Now,
+		tracer: otel.GetTracerProvider().Tracer(
+			instrumentationName,
+			trace.WithInstrumentationVersion(semanticVersion),
+		),
+		propagator: otel.GetTextMapPropagator(),
+		meter: global.MeterProvider().Meter(
+			instrumentationName,
+			metric.WithInstrumentationVersion(semanticVersion),
+		),
+	}
+	for _, opt := range options {
+		opt.apply(&cfg)
+	}
+	return &Interceptor{
 		config: cfg,
 	}
 }
 
-func (i *interceptor) getAndInitInstrument(isClient bool) (*instruments, error) {
+func (i *Interceptor) getAndInitInstrument(isClient bool) (*instruments, error) {
 	if isClient {
 		i.clientInstruments.init(i.config.meter, isClient)
 		return &i.clientInstruments, i.clientInstruments.initErr
@@ -49,7 +74,7 @@ func (i *interceptor) getAndInitInstrument(isClient bool) (*instruments, error) 
 }
 
 // WrapUnary implements otel tracing and metrics for unary handlers.
-func (i *interceptor) WrapUnary(next connect.UnaryFunc) connect.UnaryFunc {
+func (i *Interceptor) WrapUnary(next connect.UnaryFunc) connect.UnaryFunc {
 	return func(ctx context.Context, request connect.AnyRequest) (connect.AnyResponse, error) {
 		requestStartTime := i.config.now()
 		req := &Request{
@@ -141,7 +166,7 @@ func (i *interceptor) WrapUnary(next connect.UnaryFunc) connect.UnaryFunc {
 }
 
 // WrapStreamingClient implements otel tracing and metrics for streaming connect clients.
-func (i *interceptor) WrapStreamingClient(next connect.StreamingClientFunc) connect.StreamingClientFunc {
+func (i *Interceptor) WrapStreamingClient(next connect.StreamingClientFunc) connect.StreamingClientFunc {
 	return func(ctx context.Context, spec connect.Spec) connect.StreamingClientConn {
 		requestStartTime := i.config.now()
 		conn := next(ctx, spec)
@@ -206,7 +231,7 @@ func (i *interceptor) WrapStreamingClient(next connect.StreamingClientFunc) conn
 }
 
 // WrapStreamingHandler implements otel tracing and metrics for streaming connect handlers.
-func (i *interceptor) WrapStreamingHandler(next connect.StreamingHandlerFunc) connect.StreamingHandlerFunc {
+func (i *Interceptor) WrapStreamingHandler(next connect.StreamingHandlerFunc) connect.StreamingHandlerFunc {
 	return func(ctx context.Context, conn connect.StreamingHandlerConn) error {
 		requestStartTime := i.config.now()
 		isClient := conn.Spec().IsClient

--- a/interceptor_test.go
+++ b/interceptor_test.go
@@ -1687,15 +1687,17 @@ func TestStreamingSpanStatus(t *testing.T) {
 	clientSpanRecorder := tracetest.NewSpanRecorder()
 	clientTraceProvider := trace.NewTracerProvider(trace.WithSpanProcessor(clientSpanRecorder))
 	client, _, _ := startServer(
-		[]connect.HandlerOption{WithTelemetry(
-			WithPropagator(propagator),
-			WithTracerProvider(handlerTraceProvider),
-		)}, []connect.ClientOption{
-			WithTelemetry(
-				WithPropagator(propagator),
-				WithTracerProvider(clientTraceProvider),
-			),
-		}, failPingServer())
+		[]connect.HandlerOption{
+			connect.WithInterceptors(
+				NewInterceptor(
+					WithPropagator(propagator),
+					WithTracerProvider(handlerTraceProvider),
+				))}, []connect.ClientOption{
+			connect.WithInterceptors(
+				NewInterceptor(
+					WithPropagator(propagator),
+					WithTracerProvider(clientTraceProvider),
+				))}, failPingServer())
 	stream := client.CumSum(context.Background())
 	assert.NoError(t, stream.Send(&pingv1.CumSumRequest{Number: 1}))
 	_, err := stream.Receive()

--- a/interceptor_test.go
+++ b/interceptor_test.go
@@ -74,7 +74,7 @@ func TestStreamingMetrics(t *testing.T) {
 	var now time.Time
 	connectClient, host, port := startServer(
 		[]connect.HandlerOption{
-			connect.WithInterceptors(New(
+			connect.WithInterceptors(NewInterceptor(
 				WithMeterProvider(meterProvider), optionFunc(func(c *config) {
 					c.now = func() time.Time {
 						now = now.Add(time.Second)
@@ -236,7 +236,7 @@ func TestStreamingMetricsClient(t *testing.T) {
 	connectClient, host, port := startServer(
 		[]connect.HandlerOption{},
 		[]connect.ClientOption{
-			connect.WithInterceptors(New(
+			connect.WithInterceptors(NewInterceptor(
 				WithMeterProvider(meterProvider), optionFunc(func(c *config) {
 					c.now = func() time.Time {
 						now = now.Add(time.Second)
@@ -399,7 +399,7 @@ func TestStreamingMetricsClientFail(t *testing.T) {
 	connectClient, host, port := startServer(
 		[]connect.HandlerOption{},
 		[]connect.ClientOption{
-			connect.WithInterceptors(New(
+			connect.WithInterceptors(NewInterceptor(
 				WithMeterProvider(meterProvider), optionFunc(func(c *config) {
 					c.now = func() time.Time {
 						now = now.Add(time.Second)
@@ -590,7 +590,7 @@ func TestStreamingMetricsFail(t *testing.T) {
 	var now time.Time
 	connectClient, host, port := startServer(
 		[]connect.HandlerOption{
-			connect.WithInterceptors(New(
+			connect.WithInterceptors(NewInterceptor(
 				WithMeterProvider(meterProvider), optionFunc(func(c *config) {
 					c.now = func() time.Time {
 						now = now.Add(time.Second)
@@ -751,7 +751,7 @@ func TestMetrics(t *testing.T) {
 	t.Parallel()
 	metricReader, meterProvider := setupMetrics()
 	var now time.Time
-	interceptor := New(WithMeterProvider(meterProvider), optionFunc(func(c *config) {
+	interceptor := NewInterceptor(WithMeterProvider(meterProvider), optionFunc(func(c *config) {
 		c.now = func() time.Time {
 			now = now.Add(time.Second)
 			return now
@@ -911,7 +911,7 @@ func TestWithoutMetrics(t *testing.T) {
 			metricReader,
 		),
 	)
-	interceptor := New(WithMeterProvider(meterProvider), WithoutMetrics())
+	interceptor := NewInterceptor(WithMeterProvider(meterProvider), WithoutMetrics())
 	pingClient, _, _ := startServer(nil, []connect.ClientOption{
 		connect.WithInterceptors(interceptor),
 	}, happyPingServer())
@@ -932,7 +932,7 @@ func TestWithoutTracing(t *testing.T) {
 	spanRecorder := tracetest.NewSpanRecorder()
 	traceProvider := trace.NewTracerProvider(trace.WithSpanProcessor(spanRecorder))
 	pingClient, _, _ := startServer([]connect.HandlerOption{
-		connect.WithInterceptors(New(WithTracerProvider(traceProvider), WithoutTracing())),
+		connect.WithInterceptors(NewInterceptor(WithTracerProvider(traceProvider), WithoutTracing())),
 	}, nil, happyPingServer())
 	if _, err := pingClient.Ping(context.Background(), requestOfSize(1, 0)); err != nil {
 		t.Errorf(err.Error())
@@ -947,7 +947,7 @@ func TestClientSimple(t *testing.T) {
 	clientSpanRecorder := tracetest.NewSpanRecorder()
 	clientTraceProvider := trace.NewTracerProvider(trace.WithSpanProcessor(clientSpanRecorder))
 	pingClient, host, port := startServer(nil, []connect.ClientOption{
-		connect.WithInterceptors(New(WithTracerProvider(clientTraceProvider))),
+		connect.WithInterceptors(NewInterceptor(WithTracerProvider(clientTraceProvider))),
 	}, happyPingServer())
 	if _, err := pingClient.Ping(context.Background(), requestOfSize(1, 0)); err != nil {
 		t.Errorf(err.Error())
@@ -990,7 +990,7 @@ func TestHandlerFailCall(t *testing.T) {
 	clientSpanRecorder := tracetest.NewSpanRecorder()
 	clientTraceProvider := trace.NewTracerProvider(trace.WithSpanProcessor(clientSpanRecorder))
 	pingClient, host, port := startServer(nil, []connect.ClientOption{
-		connect.WithInterceptors(New(WithTracerProvider(clientTraceProvider))),
+		connect.WithInterceptors(NewInterceptor(WithTracerProvider(clientTraceProvider))),
 	}, happyPingServer())
 	_, err := pingClient.Fail(
 		context.Background(),
@@ -1039,11 +1039,11 @@ func TestClientHandlerOpts(t *testing.T) {
 	clientSpanRecorder := tracetest.NewSpanRecorder()
 	clientTraceProvider := trace.NewTracerProvider(trace.WithSpanProcessor(clientSpanRecorder))
 	pingClient, host, port := startServer([]connect.HandlerOption{
-		connect.WithInterceptors(New(WithTracerProvider(serverTraceProvider), WithFilter(func(ctx context.Context, request *Request) bool {
+		connect.WithInterceptors(NewInterceptor(WithTracerProvider(serverTraceProvider), WithFilter(func(ctx context.Context, request *Request) bool {
 			return false
 		}))),
 	}, []connect.ClientOption{
-		connect.WithInterceptors(New(WithTracerProvider(clientTraceProvider))),
+		connect.WithInterceptors(NewInterceptor(WithTracerProvider(clientTraceProvider))),
 	}, happyPingServer())
 	if _, err := pingClient.Ping(context.Background(), requestOfSize(1, 0)); err != nil {
 		t.Errorf(err.Error())
@@ -1088,7 +1088,7 @@ func TestBasicFilter(t *testing.T) {
 	spanRecorder := tracetest.NewSpanRecorder()
 	traceProvider := trace.NewTracerProvider(trace.WithSpanProcessor(spanRecorder))
 	pingClient, _, _ := startServer([]connect.HandlerOption{
-		connect.WithInterceptors(New(WithTracerProvider(traceProvider), WithFilter(func(ctx context.Context, request *Request) bool {
+		connect.WithInterceptors(NewInterceptor(WithTracerProvider(traceProvider), WithFilter(func(ctx context.Context, request *Request) bool {
 			return false
 		}))),
 	}, nil, happyPingServer())
@@ -1109,7 +1109,7 @@ func TestFilterHeader(t *testing.T) {
 	spanRecorder := tracetest.NewSpanRecorder()
 	traceProvider := trace.NewTracerProvider(trace.WithSpanProcessor(spanRecorder))
 	pingClient, host, port := startServer([]connect.HandlerOption{
-		connect.WithInterceptors(New(WithTracerProvider(traceProvider), WithFilter(func(ctx context.Context, request *Request) bool {
+		connect.WithInterceptors(NewInterceptor(WithTracerProvider(traceProvider), WithFilter(func(ctx context.Context, request *Request) bool {
 			return request.Header.Get(headerKey) == headerVal
 		}))),
 	}, nil, happyPingServer())
@@ -1160,7 +1160,7 @@ func TestInterceptors(t *testing.T) {
 	spanRecorder := tracetest.NewSpanRecorder()
 	traceProvider := trace.NewTracerProvider(trace.WithSpanProcessor(spanRecorder))
 	pingClient, host, port := startServer([]connect.HandlerOption{
-		connect.WithInterceptors(New(WithTracerProvider(traceProvider))),
+		connect.WithInterceptors(NewInterceptor(WithTracerProvider(traceProvider))),
 	}, nil, happyPingServer())
 	if _, err := pingClient.Ping(context.Background(), requestOfSize(1, 0)); err != nil {
 		t.Errorf(err.Error())
@@ -1237,7 +1237,7 @@ func TestUnaryHandlerNoTraceParent(t *testing.T) {
 		return connect.NewResponse(&pingv1.PingResponse{Id: req.Msg.Id}), nil
 	}
 	client, _, _ := startServer([]connect.HandlerOption{
-		connect.WithInterceptors(New(
+		connect.WithInterceptors(NewInterceptor(
 			WithPropagator(propagation.TraceContext{}),
 			WithTracerProvider(trace.NewTracerProvider()),
 		)),
@@ -1255,7 +1255,7 @@ func TestStreamingHandlerNoTraceParent(t *testing.T) {
 		return nil
 	}
 	client, _, _ := startServer([]connect.HandlerOption{
-		connect.WithInterceptors(New(
+		connect.WithInterceptors(NewInterceptor(
 			WithPropagator(propagation.TraceContext{}),
 			WithTracerProvider(trace.NewTracerProvider()),
 		)),
@@ -1279,12 +1279,12 @@ func TestUnaryPropagation(t *testing.T) {
 	ctx, rootSpan := trace.NewTracerProvider().Tracer("test").Start(context.Background(), "test")
 	defer rootSpan.End()
 	client, _, _ := startServer(
-		[]connect.HandlerOption{connect.WithInterceptors(New(
+		[]connect.HandlerOption{connect.WithInterceptors(NewInterceptor(
 			WithPropagator(propagator),
 			WithTracerProvider(handlerTraceProvider),
 			WithTrustRemote(),
 		))}, []connect.ClientOption{
-			connect.WithInterceptors(New(
+			connect.WithInterceptors(NewInterceptor(
 				WithPropagator(propagator),
 				WithTracerProvider(clientTraceProvider),
 			)),
@@ -1309,7 +1309,7 @@ func TestUnaryInterceptorPropagation(t *testing.T) {
 				return unaryFunc(ctx, request)
 			}
 		})),
-		connect.WithInterceptors(New(
+		connect.WithInterceptors(NewInterceptor(
 			WithPropagator(propagation.TraceContext{}),
 			WithTracerProvider(traceProvider),
 			WithTrustRemote(),
@@ -1334,11 +1334,11 @@ func TestWithUntrustedRemoteUnary(t *testing.T) {
 	ctx, rootSpan := trace.NewTracerProvider().Tracer("test").Start(context.Background(), "test")
 	defer rootSpan.End()
 	client, _, _ := startServer(
-		[]connect.HandlerOption{connect.WithInterceptors(New(
+		[]connect.HandlerOption{connect.WithInterceptors(NewInterceptor(
 			WithPropagator(propagator),
 			WithTracerProvider(handlerTraceProvider),
 		))}, []connect.ClientOption{
-			connect.WithInterceptors(New(
+			connect.WithInterceptors(NewInterceptor(
 				WithPropagator(propagator),
 				WithTracerProvider(clientTraceProvider),
 			)),
@@ -1363,7 +1363,7 @@ func TestStreamingHandlerInterceptorPropagation(t *testing.T) {
 				return handlerFunc(ctx, conn)
 			}
 		})),
-		connect.WithInterceptors(New(
+		connect.WithInterceptors(NewInterceptor(
 			WithPropagator(propagation.TraceContext{}),
 			WithTracerProvider(traceProvider),
 		)),
@@ -1388,12 +1388,12 @@ func TestStreamingPropagation(t *testing.T) {
 	ctx, rootSpan := trace.NewTracerProvider().Tracer("test").Start(context.Background(), "test")
 	defer rootSpan.End()
 	client, _, _ := startServer(
-		[]connect.HandlerOption{connect.WithInterceptors(New(
+		[]connect.HandlerOption{connect.WithInterceptors(NewInterceptor(
 			WithPropagator(propagator),
 			WithTracerProvider(handlerTraceProvider),
 			WithTrustRemote(),
 		))}, []connect.ClientOption{
-			connect.WithInterceptors(New(
+			connect.WithInterceptors(NewInterceptor(
 				WithPropagator(propagator),
 				WithTracerProvider(clientTraceProvider),
 			)),
@@ -1416,11 +1416,11 @@ func TestWithUntrustedRemoteStreaming(t *testing.T) {
 	ctx, rootSpan := trace.NewTracerProvider().Tracer("test").Start(context.Background(), "test")
 	defer rootSpan.End()
 	client, _, _ := startServer(
-		[]connect.HandlerOption{connect.WithInterceptors(New(
+		[]connect.HandlerOption{connect.WithInterceptors(NewInterceptor(
 			WithPropagator(propagator),
 			WithTracerProvider(handlerTraceProvider),
 		))}, []connect.ClientOption{
-			connect.WithInterceptors(New(
+			connect.WithInterceptors(NewInterceptor(
 				WithPropagator(propagator),
 				WithTracerProvider(clientTraceProvider),
 			)),
@@ -1441,7 +1441,7 @@ func TestStreamingClientPropagation(t *testing.T) {
 		return nil
 	}
 	client, _, _ := startServer(nil, []connect.ClientOption{
-		connect.WithInterceptors(New(
+		connect.WithInterceptors(NewInterceptor(
 			WithPropagator(propagation.TraceContext{}),
 			WithTracerProvider(trace.NewTracerProvider()),
 		)),
@@ -1460,7 +1460,7 @@ func TestStreamingHandlerTracing(t *testing.T) {
 	spanRecorder := tracetest.NewSpanRecorder()
 	traceProvider := trace.NewTracerProvider(trace.WithSpanProcessor(spanRecorder))
 	pingClient, host, port := startServer([]connect.HandlerOption{
-		connect.WithInterceptors(New(WithTracerProvider(traceProvider))),
+		connect.WithInterceptors(NewInterceptor(WithTracerProvider(traceProvider))),
 	}, nil, happyPingServer())
 	stream := pingClient.CumSum(context.Background())
 
@@ -1515,7 +1515,7 @@ func TestStreamingClientTracing(t *testing.T) {
 	spanRecorder := tracetest.NewSpanRecorder()
 	traceProvider := trace.NewTracerProvider(trace.WithSpanProcessor(spanRecorder))
 	pingClient, host, port := startServer(nil, []connect.ClientOption{
-		connect.WithInterceptors(New(WithTracerProvider(traceProvider))),
+		connect.WithInterceptors(NewInterceptor(WithTracerProvider(traceProvider))),
 	}, happyPingServer())
 	stream := pingClient.CumSum(context.Background())
 
@@ -1562,7 +1562,7 @@ func TestWithAttributeFilter(t *testing.T) {
 	spanRecorder := tracetest.NewSpanRecorder()
 	traceProvider := trace.NewTracerProvider(trace.WithSpanProcessor(spanRecorder))
 	pingClient, host, port := startServer(nil, []connect.ClientOption{
-		connect.WithInterceptors(New(
+		connect.WithInterceptors(NewInterceptor(
 			WithTracerProvider(traceProvider),
 			WithAttributeFilter(func(request *Request, value attribute.KeyValue) bool {
 				if value.Key == semconv.MessageIDKey {
@@ -1618,7 +1618,7 @@ func TestWithoutServerPeerAttributes(t *testing.T) {
 	spanRecorder := tracetest.NewSpanRecorder()
 	traceProvider := trace.NewTracerProvider(trace.WithSpanProcessor(spanRecorder))
 	pingClient, _, _ := startServer([]connect.HandlerOption{
-		connect.WithInterceptors(New(
+		connect.WithInterceptors(NewInterceptor(
 			WithTracerProvider(traceProvider),
 			WithoutServerPeerAttributes(),
 		)),

--- a/option.go
+++ b/option.go
@@ -88,7 +88,7 @@ func WithoutServerPeerAttributes() Option {
 	})
 }
 
-// WithTrustRemote sets the interceptor to trust remote spans.
+// WithTrustRemote sets the Interceptor to trust remote spans.
 // By default, all incoming server spans are untrusted and will be linked
 // with a [trace.Link] and will not be a child span.
 // By default, all client spans are trusted and no change occurs when WithTrustRemote is used.

--- a/otelconnect.go
+++ b/otelconnect.go
@@ -52,14 +52,9 @@ type config struct {
 	trustRemote     bool
 }
 
-// WithTelemetry returns a [connect.Option] that adds OpenTelemetry metrics
+// New constructs and returns a [connect.Interceptor] that adds OpenTelemetry metrics
 // and tracing to Connect handlers and clients.
-func WithTelemetry(options ...Option) connect.Option {
-	return connect.WithInterceptors(NewInterceptor(options...))
-}
-
-// NewInterceptor constructs and returns a [connect.Interceptor] for metrics and tracing.
-func NewInterceptor(options ...Option) connect.Interceptor {
+func New(options ...Option) connect.Interceptor {
 	cfg := config{
 		now: time.Now,
 		tracer: otel.GetTracerProvider().Tracer(

--- a/otelconnect.go
+++ b/otelconnect.go
@@ -20,9 +20,7 @@ import (
 	"time"
 
 	"github.com/bufbuild/connect-go"
-	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/metric"
-	"go.opentelemetry.io/otel/metric/global"
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
 )
@@ -50,26 +48,4 @@ type config struct {
 	propagator      propagation.TextMapPropagator
 	now             func() time.Time
 	trustRemote     bool
-}
-
-// NewInterceptor constructs and returns a [connect.Interceptor] that adds OpenTelemetry metrics
-// and tracing to Connect handlers and clients.
-func NewInterceptor(options ...Option) connect.Interceptor {
-	cfg := config{
-		now: time.Now,
-		tracer: otel.GetTracerProvider().Tracer(
-			instrumentationName,
-			trace.WithInstrumentationVersion(semanticVersion),
-		),
-		propagator: otel.GetTextMapPropagator(),
-		meter: global.MeterProvider().Meter(
-			instrumentationName,
-			metric.WithInstrumentationVersion(semanticVersion),
-		),
-	}
-	for _, opt := range options {
-		opt.apply(&cfg)
-	}
-	intercept := newInterceptor(cfg)
-	return intercept
 }

--- a/otelconnect.go
+++ b/otelconnect.go
@@ -52,9 +52,9 @@ type config struct {
 	trustRemote     bool
 }
 
-// New constructs and returns a [connect.Interceptor] that adds OpenTelemetry metrics
+// NewInterceptor constructs and returns a [connect.Interceptor] that adds OpenTelemetry metrics
 // and tracing to Connect handlers and clients.
-func New(options ...Option) connect.Interceptor {
+func NewInterceptor(options ...Option) connect.Interceptor {
 	cfg := config{
 		now: time.Now,
 		tracer: otel.GetTracerProvider().Tracer(


### PR DESCRIPTION
The only use case we have of using this package is using a number of Interceptors instead of just the `WithTelemetry` option. It's anticipated that if a project is using connect-opentelemetry-go the chances are that it's probably also using other interceptors. In that case it makes sense to expose a `New` function that returns an `type interceptor struct` that can be plugged into the existing interceptor plumming. 

The only difference this makes to existing projects that are using `WithTelemetry` is that they now need to use `connect.WithInterceptor(otelconnect.New())`

Fixes: https://github.com/bufbuild/connect-opentelemetry-go/issues/21