### PR TITLE
Semconv conformance to connect specification

### DIFF
--- a/attributes.go
+++ b/attributes.go
@@ -98,13 +98,13 @@ func statusCodeAttribute(protocol string, serverErr error) (attribute.KeyValue, 
 	// Following the respective specifications, use integers and "status_code" for
 	// gRPC codes in contrast to strings and "error_code" for Connect codes.
 	switch protocol {
-	case "grpc", "grpc_web":
+	case grpcProtocol, grpcwebProtocol:
 		codeKey := attribute.Key("rpc." + protocol + ".status_code")
 		if serverErr != nil {
 			return codeKey.Int64(int64(connect.CodeOf(serverErr))), true
 		}
 		return codeKey.Int64(0), true // gRPC uses 0 for success
-	case "connect_rpc":
+	case connectProtocol:
 		codeKey := attribute.Key("rpc." + protocol + ".error_code")
 		if serverErr != nil {
 			return codeKey.String(connect.CodeOf(serverErr).String()), true

--- a/interceptor.go
+++ b/interceptor.go
@@ -307,7 +307,7 @@ func protocolToSemConv(protocol string) string {
 	case "grpc":
 		return "grpc"
 	case "connect":
-		return "buf_connect"
+		return "connect_rpc"
 	default:
 		return protocol
 	}

--- a/interceptor.go
+++ b/interceptor.go
@@ -308,12 +308,12 @@ func (i *Interceptor) WrapStreamingHandler(next connect.StreamingHandlerFunc) co
 
 func protocolToSemConv(protocol string) string {
 	switch protocol {
-	case "grpcweb":
-		return "grpc_web"
-	case "grpc":
-		return "grpc"
-	case "connect":
-		return "connect_rpc"
+	case grpcwebString:
+		return grpcwebProtocol
+	case grpcProtocol:
+		return grpcProtocol
+	case connectString:
+		return connectProtocol
 	default:
 		return protocol
 	}

--- a/interceptor_test.go
+++ b/interceptor_test.go
@@ -51,7 +51,7 @@ import (
 const (
 	messagesPerRequest       = 2
 	successString            = "success"
-	bufConnect               = "buf_connect"
+	bufConnect               = "connect_rpc"
 	CumSumMethod             = "CumSum"
 	PingMethod               = "Ping"
 	FailMethod               = "Fail"
@@ -67,7 +67,7 @@ const (
 	rpcServerResponseSize    = "rpc.server.response.size"
 	rpcServerRequestsPerRPC  = "rpc.server.requests_per_rpc"
 	rpcServerResponsesPerRPC = "rpc.server.responses_per_rpc"
-	rpcBufConnectStatusCode  = "rpc.buf_connect.status_code"
+	rpcBufConnectStatusCode  = "rpc.connect_rpc.status_code"
 )
 
 func TestStreamingMetrics(t *testing.T) {

--- a/interceptor_test.go
+++ b/interceptor_test.go
@@ -50,7 +50,6 @@ import (
 
 const (
 	messagesPerRequest       = 2
-	successString            = "success"
 	bufConnect               = "connect_rpc"
 	CumSumMethod             = "CumSum"
 	PingMethod               = "Ping"
@@ -67,7 +66,7 @@ const (
 	rpcServerResponseSize    = "rpc.server.response.size"
 	rpcServerRequestsPerRPC  = "rpc.server.requests_per_rpc"
 	rpcServerResponsesPerRPC = "rpc.server.responses_per_rpc"
-	rpcBufConnectStatusCode  = "rpc.connect_rpc.status_code"
+	rpcBufConnectStatusCode  = "rpc.connect_rpc.error_code"
 )
 
 func TestStreamingMetrics(t *testing.T) {
@@ -117,7 +116,6 @@ func TestStreamingMetrics(t *testing.T) {
 									Attributes: attribute.NewSet(
 										semconv.NetPeerNameKey.String(host),
 										semconv.NetPeerPortKey.Int(port),
-										attribute.Key(rpcBufConnectStatusCode).String(successString),
 										semconv.RPCSystemKey.String(bufConnect),
 										semconv.RPCServiceKey.String(pingv1connect.PingServiceName),
 										semconv.RPCMethodKey.String(CumSumMethod),
@@ -283,7 +281,6 @@ func TestStreamingMetricsClient(t *testing.T) {
 										semconv.RPCSystemKey.String(bufConnect),
 										semconv.RPCServiceKey.String(pingv1connect.PingServiceName),
 										semconv.RPCMethodKey.String(CumSumMethod),
-										attribute.Key(rpcBufConnectStatusCode).String(successString),
 									),
 									Count: 1,
 									Sum:   1000.0,
@@ -787,7 +784,6 @@ func TestMetrics(t *testing.T) {
 									Attributes: attribute.NewSet(
 										semconv.NetPeerNameKey.String(host),
 										semconv.NetPeerPortKey.Int(port),
-										attribute.Key(rpcBufConnectStatusCode).String(successString),
 										semconv.RPCMethodKey.String(PingMethod),
 										semconv.RPCServiceKey.String(pingv1connect.PingServiceName),
 										semconv.RPCSystemKey.String(bufConnect),
@@ -810,7 +806,6 @@ func TestMetrics(t *testing.T) {
 									Attributes: attribute.NewSet(
 										semconv.NetPeerNameKey.String(host),
 										semconv.NetPeerPortKey.Int(port),
-										attribute.Key(rpcBufConnectStatusCode).String(successString),
 										semconv.RPCMethodKey.String(PingMethod),
 										semconv.RPCServiceKey.String(pingv1connect.PingServiceName),
 										semconv.RPCSystemKey.String(bufConnect),
@@ -833,7 +828,6 @@ func TestMetrics(t *testing.T) {
 									Attributes: attribute.NewSet(
 										semconv.NetPeerNameKey.String(host),
 										semconv.NetPeerPortKey.Int(port),
-										attribute.Key(rpcBufConnectStatusCode).String(successString),
 										semconv.RPCMethodKey.String(PingMethod),
 										semconv.RPCServiceKey.String(pingv1connect.PingServiceName),
 										semconv.RPCSystemKey.String(bufConnect),
@@ -856,7 +850,6 @@ func TestMetrics(t *testing.T) {
 									Attributes: attribute.NewSet(
 										semconv.NetPeerNameKey.String(host),
 										semconv.NetPeerPortKey.Int(port),
-										attribute.Key(rpcBufConnectStatusCode).String(successString),
 										semconv.RPCMethodKey.String(PingMethod),
 										semconv.RPCServiceKey.String(pingv1connect.PingServiceName),
 										semconv.RPCSystemKey.String(bufConnect),
@@ -879,7 +872,6 @@ func TestMetrics(t *testing.T) {
 									Attributes: attribute.NewSet(
 										semconv.NetPeerNameKey.String(host),
 										semconv.NetPeerPortKey.Int(port),
-										attribute.Key(rpcBufConnectStatusCode).String(successString),
 										semconv.RPCMethodKey.String(PingMethod),
 										semconv.RPCServiceKey.String(pingv1connect.PingServiceName),
 										semconv.RPCSystemKey.String(bufConnect),
@@ -983,7 +975,6 @@ func TestClientSimple(t *testing.T) {
 				semconv.RPCSystemKey.String(bufConnect),
 				semconv.RPCServiceKey.String(pingv1connect.PingServiceName),
 				semconv.RPCMethodKey.String(PingMethod),
-				attribute.Key(rpcBufConnectStatusCode).String(successString),
 			},
 		},
 	}, clientSpanRecorder.Ended())
@@ -1084,7 +1075,6 @@ func TestClientHandlerOpts(t *testing.T) {
 				semconv.RPCSystemKey.String(bufConnect),
 				semconv.RPCServiceKey.String(pingv1connect.PingServiceName),
 				semconv.RPCMethodKey.String(PingMethod),
-				attribute.Key(rpcBufConnectStatusCode).String(successString),
 			},
 		},
 	}, clientSpanRecorder.Ended())
@@ -1156,7 +1146,6 @@ func TestFilterHeader(t *testing.T) {
 				semconv.RPCSystemKey.String(bufConnect),
 				semconv.RPCServiceKey.String(pingv1connect.PingServiceName),
 				semconv.RPCMethodKey.String(PingMethod),
-				attribute.Key(rpcBufConnectStatusCode).String(successString),
 			},
 		},
 	}, spanRecorder.Ended())
@@ -1203,7 +1192,6 @@ func TestInterceptors(t *testing.T) {
 				semconv.RPCSystemKey.String(bufConnect),
 				semconv.RPCServiceKey.String(pingv1connect.PingServiceName),
 				semconv.RPCMethodKey.String(PingMethod),
-				attribute.Key(rpcBufConnectStatusCode).String(successString),
 			},
 		},
 		{
@@ -1232,7 +1220,6 @@ func TestInterceptors(t *testing.T) {
 				semconv.RPCSystemKey.String(bufConnect),
 				semconv.RPCServiceKey.String(pingv1connect.PingServiceName),
 				semconv.RPCMethodKey.String(PingMethod),
-				attribute.Key(rpcBufConnectStatusCode).String(successString),
 			},
 		},
 	}, spanRecorder.Ended())
@@ -1549,7 +1536,6 @@ func TestStreamingHandlerTracing(t *testing.T) {
 				semconv.RPCSystemKey.String(bufConnect),
 				semconv.RPCServiceKey.String(pingv1connect.PingServiceName),
 				semconv.RPCMethodKey.String(CumSumMethod),
-				attribute.Key(rpcBufConnectStatusCode).String(successString),
 			},
 		},
 	}, spanRecorder.Ended())
@@ -1598,7 +1584,6 @@ func TestStreamingClientTracing(t *testing.T) {
 				semconv.RPCSystemKey.String(bufConnect),
 				semconv.RPCServiceKey.String(pingv1connect.PingServiceName),
 				semconv.RPCMethodKey.String(CumSumMethod),
-				attribute.Key(rpcBufConnectStatusCode).String(successString),
 			},
 		},
 	}, spanRecorder.Ended())
@@ -1654,7 +1639,6 @@ func TestWithAttributeFilter(t *testing.T) {
 				semconv.NetPeerPortKey.Int(port),
 				semconv.RPCSystemKey.String(bufConnect),
 				semconv.RPCMethodKey.String(CumSumMethod),
-				attribute.Key(rpcBufConnectStatusCode).String(successString),
 			},
 		},
 	}, spanRecorder.Ended())
@@ -1709,7 +1693,6 @@ func TestWithoutServerPeerAttributes(t *testing.T) {
 				semconv.RPCSystemKey.String(bufConnect),
 				semconv.RPCServiceKey.String(pingv1connect.PingServiceName),
 				semconv.RPCMethodKey.String(CumSumMethod),
-				attribute.Key(rpcBufConnectStatusCode).String(successString),
 			},
 		},
 	}, spanRecorder.Ended())

--- a/otelconnect.go
+++ b/otelconnect.go
@@ -29,6 +29,11 @@ const (
 	version             = "0.0.1-dev"
 	semanticVersion     = "semver:" + version
 	instrumentationName = "github.com/bufbuild/connect-opentelemetry-go"
+	grpcProtocol        = "grpc"
+	grpcwebString       = "grpcweb"
+	grpcwebProtocol     = "grpc_web"
+	connectString       = "connect"
+	connectProtocol     = "connect_rpc"
 )
 
 // Request is the information about each RPC available to filter functions. It

--- a/streaming.go
+++ b/streaming.go
@@ -81,7 +81,9 @@ func (s *streamingState) receive(ctx context.Context, msg any, conn sendReceiver
 		s.error = err
 		// If error add it to the attributes because the stream is about to terminate.
 		// If no error don't add anything because status only exists at end of stream.
-		s.addAttributes(statusCodeAttribute(s.protocol, err))
+		if statusCode, ok := statusCodeAttribute(s.protocol, err); ok {
+			s.addAttributes(statusCode)
+		}
 	}
 	protomsg, ok := msg.(proto.Message)
 	size := proto.Size(protomsg)
@@ -103,7 +105,9 @@ func (s *streamingState) send(ctx context.Context, msg any, conn sendReceiver) e
 		s.error = err
 		// If error add it to the attributes because the stream is about to terminate.
 		// If no error don't add anything because status only exists at end of stream.
-		s.addAttributes(statusCodeAttribute(s.protocol, err))
+		if statusCode, ok := statusCodeAttribute(s.protocol, err); ok {
+			s.addAttributes(statusCode)
+		}
 	}
 	protomsg, ok := msg.(proto.Message)
 	size := proto.Size(protomsg)


### PR DESCRIPTION
Conforms to https://github.com/open-telemetry/opentelemetry-specification/pull/3116 

Namely:
- `buf_connect` is not `connect_rpc` 
- `status_code` is now `error_code` for `connect_rpc` instances. This means that no attribute is set for success
- introduce string consts for grpc, grpcweb connect_rpc...