### PR TITLE
Format README.md with gofmt

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,51 +22,51 @@ quickstart][otel-go-quickstart].
 package main
 
 import (
-  "context"
-  "fmt"
-  "log"
-  "net/http"
+	"context"
+	"fmt"
+	"log"
+	"net/http"
 
-  "github.com/bufbuild/connect-go"
-  otelconnect "github.com/bufbuild/connect-opentelemetry-go"
-
-  // Generated from your protobuf schema by protoc-gen-go and
-  // protoc-gen-connect-go.
-  pingv1 "github.com/bufbuild/connect-opentelemetry-go/internal/gen/observability/ping/v1"
-  "github.com/bufbuild/connect-opentelemetry-go/internal/gen/observability/ping/v1/pingv1connect"
+	"github.com/bufbuild/connect-go"
+	otelconnect "github.com/bufbuild/connect-opentelemetry-go"
+	// Generated from your protobuf schema by protoc-gen-go and
+	// protoc-gen-connect-go.
+	pingv1 "github.com/bufbuild/connect-opentelemetry-go/internal/gen/observability/ping/v1"
+	"github.com/bufbuild/connect-opentelemetry-go/internal/gen/observability/ping/v1/pingv1connect"
 )
 
 func main() {
-  mux := http.NewServeMux()
+	mux := http.NewServeMux()
 
-  // otelconnect.New provides an interceptor that adds tracing and metrics to both clients and
-  // handlers. By default, it uses OpenTelemetry's global TracerProvider and
-  // MeterProvider, which you can configure by following the OpenTelemetry
-  // documentation. If you'd prefer to avoid globals, use
-  // otelconnect.WithTracerProvider and otelconnect.WithMeterProvider.
-  mux.Handle(pingv1connect.NewPingServiceHandler(
-    &pingv1connect.UnimplementedPingServiceHandler{},
-	  connect.WithInterceptors(otelconnect.NewInterceptor()),
-  ))
+	// otelconnect.New provides an interceptor that adds tracing and metrics to both clients and
+	// handlers. By default, it uses OpenTelemetry's global TracerProvider and
+	// MeterProvider, which you can configure by following the OpenTelemetry
+	// documentation. If you'd prefer to avoid globals, use
+	// otelconnect.WithTracerProvider and otelconnect.WithMeterProvider.
+	mux.Handle(pingv1connect.NewPingServiceHandler(
+		&pingv1connect.UnimplementedPingServiceHandler{},
+		connect.WithInterceptors(otelconnect.NewInterceptor()),
+	))
 
-  http.ListenAndServe("localhost:8080", mux)
+	http.ListenAndServe("localhost:8080", mux)
 }
 
 func makeRequest() {
-  client := pingv1connect.NewPingServiceClient(
-    http.DefaultClient,
-    "http://localhost:8080",
-    connect.WithInterceptors(otelconnect.NewInterceptor()),
-  )
-  resp, err := client.Ping(
-    context.Background(),
-    connect.NewRequest(&pingv1.PingRequest{}),
-  )
-  if err != nil {
-    log.Fatal(err)
-  }
-  fmt.Println(resp)
+	client := pingv1connect.NewPingServiceClient(
+		http.DefaultClient,
+		"http://localhost:8080",
+		connect.WithInterceptors(otelconnect.NewInterceptor()),
+	)
+	resp, err := client.Ping(
+		context.Background(),
+		connect.NewRequest(&pingv1.PingRequest{}),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println(resp)
 }
+
 ```
 
 ## Status


### PR DESCRIPTION
So the underlying problem with https://github.com/bufbuild/connect-opentelemetry-go/pull/71 is that the README go source got formatted with spaces somewhere along the line. 

This runs `gofumpt` on the README code. 

[From Effective go](https://go.dev/doc/effective_go#formatting):
> Indentation
We use tabs for indentation and gofmt emits them by default. Use spaces only if you must.