### PR TITLE
Update to go v1.19 + connect-go v1.5.2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.18.x,1.19.x]
+        go-version: [1.19.x,1.20.x]
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/bufbuild/connect-opentelemetry-go
 
-go 1.18
+go 1.19
 
 require (
 	github.com/bufbuild/connect-go v1.5.1

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/bufbuild/connect-opentelemetry-go
 go 1.19
 
 require (
-	github.com/bufbuild/connect-go v1.5.1
+	github.com/bufbuild/connect-go v1.5.2
 	github.com/google/go-cmp v0.5.9
 	github.com/stretchr/testify v1.8.2
 	go.opentelemetry.io/otel v1.13.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/bufbuild/connect-go v1.5.1 h1:ORhrSiu63hWxtuMmC/V1mKySSRhEySsW5RkHJcyJXBk=
-github.com/bufbuild/connect-go v1.5.1/go.mod h1:9iNvh/NOsfhNBUH5CtvXeVUskQO1xsrEviH7ZArwZ3I=
+github.com/bufbuild/connect-go v1.5.2 h1:G4EZd5gF1U1ZhhbVJXplbuUnfKpBZ5j5izqIwu2g2W8=
+github.com/bufbuild/connect-go v1.5.2/go.mod h1:GmMJYR6orFqD0Y6ZgX8pwQ8j9baizDrIQMm1/a6LnHk=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
connect-go v1.5.2 requires go 1.19, this updates both 