### PR TITLE
Remove reference to `untagged alpha release` for preparation of v0.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ func makeRequest() {
 
 ## Status
 
-`connect-opentelemetry-go` is available as an untagged alpha release.
+`connect-opentelemetry-go` is available as a beta release.
 
 |         | Unary | Streaming Client | Streaming Handler |
 |---------|:-----:|:----------------:|:-----------------:|


### PR DESCRIPTION
I am about to release `v0.1.0` of this repo, so this removes references to `untagged alpha release` 