### PR TITLE
add new option to omit adding RPC events in unary interceptor

### DIFF
--- a/interceptor.go
+++ b/interceptor.go
@@ -135,13 +135,17 @@ func (i *Interceptor) WrapUnary(next connect.UnaryFunc) connect.UnaryFunc {
 				requestSize = proto.Size(msg)
 			}
 		}
-		span.AddEvent(messageKey,
-			trace.WithAttributes(
-				requestSpan,
-				semconv.MessageIDKey.Int(1),
-				semconv.MessageUncompressedSizeKey.Int(requestSize),
-			),
-		)
+
+		if !i.config.omitRPCEvents {
+			span.AddEvent(messageKey,
+				trace.WithAttributes(
+					requestSpan,
+					semconv.MessageIDKey.Int(1),
+					semconv.MessageUncompressedSizeKey.Int(requestSize),
+				),
+			)
+		}
+
 		response, err := next(ctx, request)
 		if statusCode, ok := statusCodeAttribute(protocol, err); ok {
 			attributes = append(attributes, statusCode)
@@ -153,13 +157,17 @@ func (i *Interceptor) WrapUnary(next connect.UnaryFunc) connect.UnaryFunc {
 			}
 			span.SetAttributes(headerAttributes(protocol, responseKey, response.Header(), i.config.responseHeaderKeys)...)
 		}
-		span.AddEvent(messageKey,
-			trace.WithAttributes(
-				responseSpan,
-				semconv.MessageIDKey.Int(1),
-				semconv.MessageUncompressedSizeKey.Int(responseSize),
-			),
-		)
+
+		if !i.config.omitRPCEvents {
+			span.AddEvent(messageKey,
+				trace.WithAttributes(
+					responseSpan,
+					semconv.MessageIDKey.Int(1),
+					semconv.MessageUncompressedSizeKey.Int(responseSize),
+				),
+			)
+		}
+
 		attributes = attributeFilter(req, attributes...)
 		span.SetStatus(spanStatus(err))
 		span.SetAttributes(attributes...)

--- a/option.go
+++ b/option.go
@@ -113,6 +113,10 @@ func WithTraceResponseHeader(keys ...string) Option {
 	}
 }
 
+func WithoutRPCEvents() Option {
+	return &omitRPCEventsOption{}
+}
+
 type attributeFilterOption struct {
 	filterAttribute AttributeFilter
 }
@@ -191,4 +195,10 @@ func (o *traceResponseHeaderOption) apply(c *config) {
 	for _, key := range o.keys {
 		c.responseHeaderKeys = append(c.responseHeaderKeys, http.CanonicalHeaderKey(key))
 	}
+}
+
+type omitRPCEventsOption struct{}
+
+func (o *omitRPCEventsOption) apply(c *config) {
+	c.omitRPCEvents = true
 }

--- a/otelconnect.go
+++ b/otelconnect.go
@@ -55,4 +55,5 @@ type config struct {
 	trustRemote        bool
 	requestHeaderKeys  []string
 	responseHeaderKeys []string
+	omitRPCEvents      bool
 }


### PR DESCRIPTION
Addresses https://github.com/bufbuild/connect-opentelemetry-go/issues/92 with a new interceptor option to omit the sent/received events.