### PR TITLE
Update go.opentelemetry to v1.15/v0.38

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,19 +6,19 @@ require (
 	github.com/bufbuild/connect-go v1.5.2
 	github.com/google/go-cmp v0.5.9
 	github.com/stretchr/testify v1.8.2
-	go.opentelemetry.io/otel v1.14.0
-	go.opentelemetry.io/otel/metric v0.37.0
-	go.opentelemetry.io/otel/sdk v1.14.0
-	go.opentelemetry.io/otel/sdk/metric v0.37.0
-	go.opentelemetry.io/otel/trace v1.14.0
+	go.opentelemetry.io/otel v1.15.0
+	go.opentelemetry.io/otel/metric v0.38.0
+	go.opentelemetry.io/otel/sdk v1.15.0
+	go.opentelemetry.io/otel/sdk/metric v0.38.0
+	go.opentelemetry.io/otel/trace v1.15.0
 	google.golang.org/protobuf v1.30.0
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/go-logr/logr v1.2.3 // indirect
+	github.com/go-logr/logr v1.2.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	golang.org/x/sys v0.5.0 // indirect
+	golang.org/x/sys v0.7.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/instruments.go
+++ b/instruments.go
@@ -19,7 +19,6 @@ import (
 	"sync"
 
 	"go.opentelemetry.io/otel/metric"
-	"go.opentelemetry.io/otel/metric/instrument"
 )
 
 const (
@@ -42,11 +41,11 @@ const (
 type instruments struct {
 	initOnce        sync.Once
 	initErr         error
-	duration        instrument.Int64Histogram
-	requestSize     instrument.Int64Histogram
-	responseSize    instrument.Int64Histogram
-	requestsPerRPC  instrument.Int64Histogram
-	responsesPerRPC instrument.Int64Histogram
+	duration        metric.Int64Histogram
+	requestSize     metric.Int64Histogram
+	responseSize    metric.Int64Histogram
+	requestsPerRPC  metric.Int64Histogram
+	responsesPerRPC metric.Int64Histogram
 }
 
 func (i *instruments) init(meter metric.Meter, isClient bool) {
@@ -56,40 +55,40 @@ func (i *instruments) init(meter metric.Meter, isClient bool) {
 			interceptorType = clientKey
 		}
 		i.duration, i.initErr = meter.Int64Histogram(
-			formatkeys(interceptorType, durationKey),
-			instrument.WithUnit(unitMilliseconds),
+			formatKeys(interceptorType, durationKey),
+			metric.WithUnit(unitMilliseconds),
 		)
 		if i.initErr != nil {
 			return
 		}
 		i.requestSize, i.initErr = meter.Int64Histogram(
-			formatkeys(interceptorType, requestSizeKey),
-			instrument.WithUnit(unitBytes),
+			formatKeys(interceptorType, requestSizeKey),
+			metric.WithUnit(unitBytes),
 		)
 		if i.initErr != nil {
 			return
 		}
 		i.responseSize, i.initErr = meter.Int64Histogram(
-			formatkeys(interceptorType, responseSizeKey),
-			instrument.WithUnit(unitBytes),
+			formatKeys(interceptorType, responseSizeKey),
+			metric.WithUnit(unitBytes),
 		)
 		if i.initErr != nil {
 			return
 		}
 		i.requestsPerRPC, i.initErr = meter.Int64Histogram(
-			formatkeys(interceptorType, requestsPerRPCKey),
-			instrument.WithUnit(unitDimensionless),
+			formatKeys(interceptorType, requestsPerRPCKey),
+			metric.WithUnit(unitDimensionless),
 		)
 		if i.initErr != nil {
 			return
 		}
 		i.responsesPerRPC, i.initErr = meter.Int64Histogram(
-			formatkeys(interceptorType, responsesPerRPCKey),
-			instrument.WithUnit(unitDimensionless),
+			formatKeys(interceptorType, responsesPerRPCKey),
+			metric.WithUnit(unitDimensionless),
 		)
 	})
 }
 
-func formatkeys(interceptorType string, metricName string) string {
+func formatKeys(interceptorType string, metricName string) string {
 	return fmt.Sprintf(metricKeyFormat, interceptorType, metricName)
 }

--- a/interceptor.go
+++ b/interceptor.go
@@ -163,11 +163,11 @@ func (i *Interceptor) WrapUnary(next connect.UnaryFunc) connect.UnaryFunc {
 		attributes = attributeFilter(req, attributes...)
 		span.SetStatus(spanStatus(err))
 		span.SetAttributes(attributes...)
-		instrumentation.duration.Record(ctx, i.config.now().Sub(requestStartTime).Milliseconds(), attributes...)
-		instrumentation.requestSize.Record(ctx, int64(requestSize), attributes...)
-		instrumentation.requestsPerRPC.Record(ctx, 1, attributes...)
-		instrumentation.responseSize.Record(ctx, int64(responseSize), attributes...)
-		instrumentation.responsesPerRPC.Record(ctx, 1, attributes...)
+		instrumentation.duration.Record(ctx, i.config.now().Sub(requestStartTime).Milliseconds(), metric.WithAttributes(attributes...))
+		instrumentation.requestSize.Record(ctx, int64(requestSize), metric.WithAttributes(attributes...))
+		instrumentation.requestsPerRPC.Record(ctx, 1, metric.WithAttributes(attributes...))
+		instrumentation.responseSize.Record(ctx, int64(responseSize), metric.WithAttributes(attributes...))
+		instrumentation.responsesPerRPC.Record(ctx, 1, metric.WithAttributes(attributes...))
 		return response, err
 	}
 }
@@ -238,7 +238,7 @@ func (i *Interceptor) WrapStreamingClient(next connect.StreamingClientFunc) conn
 				span.SetAttributes(headerAttributes(protocol, responseKey, conn.ResponseHeader(), i.config.responseHeaderKeys)...)
 				span.SetStatus(spanStatus(state.error))
 				span.End()
-				instrumentation.duration.Record(ctx, i.config.now().Sub(requestStartTime).Milliseconds(), state.attributes...)
+				instrumentation.duration.Record(ctx, i.config.now().Sub(requestStartTime).Milliseconds(), metric.WithAttributes(state.attributes...))
 			},
 			receive: func(msg any, conn connect.StreamingClientConn) error {
 				return state.receive(ctx, msg, conn)
@@ -320,7 +320,7 @@ func (i *Interceptor) WrapStreamingHandler(next connect.StreamingHandlerFunc) co
 		span.SetAttributes(state.attributes...)
 		span.SetAttributes(headerAttributes(protocol, responseKey, conn.ResponseHeader(), i.config.responseHeaderKeys)...)
 		span.SetStatus(spanStatus(err))
-		instrumentation.duration.Record(ctx, i.config.now().Sub(requestStartTime).Milliseconds(), state.attributes...)
+		instrumentation.duration.Record(ctx, i.config.now().Sub(requestStartTime).Milliseconds(), metric.WithAttributes(state.attributes...))
 		return err
 	}
 }

--- a/interceptor_test.go
+++ b/interceptor_test.go
@@ -26,8 +26,6 @@ import (
 	"time"
 
 	"github.com/bufbuild/connect-go"
-	pingv1 "github.com/bufbuild/connect-opentelemetry-go/internal/gen/observability/ping/v1"
-	"github.com/bufbuild/connect-opentelemetry-go/internal/gen/observability/ping/v1/pingv1connect"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/assert"
@@ -45,6 +43,9 @@ import (
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	semconv "go.opentelemetry.io/otel/semconv/v1.12.0"
 	traceapi "go.opentelemetry.io/otel/trace"
+
+	pingv1 "github.com/bufbuild/connect-opentelemetry-go/internal/gen/observability/ping/v1"
+	"github.com/bufbuild/connect-opentelemetry-go/internal/gen/observability/ping/v1/pingv1connect"
 )
 
 const (
@@ -109,8 +110,8 @@ func TestStreamingMetrics(t *testing.T) {
 					{
 						Name: rpcServerDuration,
 						Unit: unitMilliseconds,
-						Data: metricdata.Histogram{
-							DataPoints: []metricdata.HistogramDataPoint{
+						Data: metricdata.Histogram[int64]{
+							DataPoints: []metricdata.HistogramDataPoint[int64]{
 								{
 									Attributes: attribute.NewSet(
 										semconv.NetPeerNameKey.String(host),
@@ -121,8 +122,8 @@ func TestStreamingMetrics(t *testing.T) {
 									),
 									Count: 1,
 									Sum:   1000.0,
-									Min:   metricdata.NewExtrema(1000),
-									Max:   metricdata.NewExtrema(1000),
+									Min:   metricdata.NewExtrema(int64(1000)),
+									Max:   metricdata.NewExtrema(int64(1000)),
 								},
 							},
 							Temporality: metricdata.CumulativeTemporality,
@@ -131,8 +132,8 @@ func TestStreamingMetrics(t *testing.T) {
 					{
 						Name: rpcServerRequestSize,
 						Unit: unitBytes,
-						Data: metricdata.Histogram{
-							DataPoints: []metricdata.HistogramDataPoint{
+						Data: metricdata.Histogram[int64]{
+							DataPoints: []metricdata.HistogramDataPoint[int64]{
 								{
 									Attributes: attribute.NewSet(
 										semconv.NetPeerNameKey.String(host),
@@ -143,8 +144,8 @@ func TestStreamingMetrics(t *testing.T) {
 									),
 									Count: 1,
 									Sum:   2.0,
-									Min:   metricdata.NewExtrema(2),
-									Max:   metricdata.NewExtrema(2),
+									Min:   metricdata.NewExtrema(int64(2)),
+									Max:   metricdata.NewExtrema(int64(2)),
 								},
 							},
 							Temporality: metricdata.CumulativeTemporality,
@@ -153,8 +154,8 @@ func TestStreamingMetrics(t *testing.T) {
 					{
 						Name: rpcServerResponseSize,
 						Unit: unitBytes,
-						Data: metricdata.Histogram{
-							DataPoints: []metricdata.HistogramDataPoint{
+						Data: metricdata.Histogram[int64]{
+							DataPoints: []metricdata.HistogramDataPoint[int64]{
 								{
 									Attributes: attribute.NewSet(
 										semconv.NetPeerNameKey.String(host),
@@ -165,8 +166,8 @@ func TestStreamingMetrics(t *testing.T) {
 									),
 									Count: 2,
 									Sum:   4.0,
-									Min:   metricdata.NewExtrema(2),
-									Max:   metricdata.NewExtrema(2),
+									Min:   metricdata.NewExtrema(int64(2)),
+									Max:   metricdata.NewExtrema(int64(2)),
 								},
 							},
 							Temporality: metricdata.CumulativeTemporality,
@@ -175,8 +176,8 @@ func TestStreamingMetrics(t *testing.T) {
 					{
 						Name: rpcServerRequestsPerRPC,
 						Unit: unitDimensionless,
-						Data: metricdata.Histogram{
-							DataPoints: []metricdata.HistogramDataPoint{
+						Data: metricdata.Histogram[int64]{
+							DataPoints: []metricdata.HistogramDataPoint[int64]{
 								{
 									Attributes: attribute.NewSet(
 										semconv.NetPeerNameKey.String(host),
@@ -187,8 +188,8 @@ func TestStreamingMetrics(t *testing.T) {
 									),
 									Count: 1,
 									Sum:   1,
-									Min:   metricdata.NewExtrema(1),
-									Max:   metricdata.NewExtrema(1),
+									Min:   metricdata.NewExtrema(int64(1)),
+									Max:   metricdata.NewExtrema(int64(1)),
 								},
 							},
 							Temporality: metricdata.CumulativeTemporality,
@@ -197,8 +198,8 @@ func TestStreamingMetrics(t *testing.T) {
 					{
 						Name: rpcServerResponsesPerRPC,
 						Unit: unitDimensionless,
-						Data: metricdata.Histogram{
-							DataPoints: []metricdata.HistogramDataPoint{
+						Data: metricdata.Histogram[int64]{
+							DataPoints: []metricdata.HistogramDataPoint[int64]{
 								{
 									Attributes: attribute.NewSet(
 										semconv.NetPeerNameKey.String(host),
@@ -209,8 +210,8 @@ func TestStreamingMetrics(t *testing.T) {
 									),
 									Count: 2,
 									Sum:   2,
-									Min:   metricdata.NewExtrema(1),
-									Max:   metricdata.NewExtrema(1),
+									Min:   metricdata.NewExtrema(int64(1)),
+									Max:   metricdata.NewExtrema(int64(1)),
 								},
 							},
 							Temporality: metricdata.CumulativeTemporality,
@@ -270,8 +271,8 @@ func TestStreamingMetricsClient(t *testing.T) {
 					{
 						Name: rpcClientDuration,
 						Unit: unitMilliseconds,
-						Data: metricdata.Histogram{
-							DataPoints: []metricdata.HistogramDataPoint{
+						Data: metricdata.Histogram[int64]{
+							DataPoints: []metricdata.HistogramDataPoint[int64]{
 								{
 									Attributes: attribute.NewSet(
 										semconv.NetPeerNameKey.String(host),
@@ -282,8 +283,8 @@ func TestStreamingMetricsClient(t *testing.T) {
 									),
 									Count: 1,
 									Sum:   1000.0,
-									Min:   metricdata.NewExtrema(1000),
-									Max:   metricdata.NewExtrema(1000),
+									Min:   metricdata.NewExtrema(int64(1000)),
+									Max:   metricdata.NewExtrema(int64(1000)),
 								},
 							},
 							Temporality: metricdata.CumulativeTemporality,
@@ -292,8 +293,8 @@ func TestStreamingMetricsClient(t *testing.T) {
 					{
 						Name: rpcClientRequestSize,
 						Unit: unitBytes,
-						Data: metricdata.Histogram{
-							DataPoints: []metricdata.HistogramDataPoint{
+						Data: metricdata.Histogram[int64]{
+							DataPoints: []metricdata.HistogramDataPoint[int64]{
 								{
 									Attributes: attribute.NewSet(
 										semconv.NetPeerNameKey.String(host),
@@ -304,8 +305,8 @@ func TestStreamingMetricsClient(t *testing.T) {
 									),
 									Count: 1,
 									Sum:   2.0,
-									Min:   metricdata.NewExtrema(2),
-									Max:   metricdata.NewExtrema(2),
+									Min:   metricdata.NewExtrema(int64(2)),
+									Max:   metricdata.NewExtrema(int64(2)),
 								},
 							},
 							Temporality: metricdata.CumulativeTemporality,
@@ -314,8 +315,8 @@ func TestStreamingMetricsClient(t *testing.T) {
 					{
 						Name: rpcClientResponseSize,
 						Unit: unitBytes,
-						Data: metricdata.Histogram{
-							DataPoints: []metricdata.HistogramDataPoint{
+						Data: metricdata.Histogram[int64]{
+							DataPoints: []metricdata.HistogramDataPoint[int64]{
 								{
 									Attributes: attribute.NewSet(
 										semconv.NetPeerNameKey.String(host),
@@ -326,8 +327,8 @@ func TestStreamingMetricsClient(t *testing.T) {
 									),
 									Count: 1,
 									Sum:   2.0,
-									Min:   metricdata.NewExtrema(2),
-									Max:   metricdata.NewExtrema(2),
+									Min:   metricdata.NewExtrema(int64(2)),
+									Max:   metricdata.NewExtrema(int64(2)),
 								},
 							},
 							Temporality: metricdata.CumulativeTemporality,
@@ -336,8 +337,8 @@ func TestStreamingMetricsClient(t *testing.T) {
 					{
 						Name: rpcClientRequestsPerRPC,
 						Unit: unitDimensionless,
-						Data: metricdata.Histogram{
-							DataPoints: []metricdata.HistogramDataPoint{
+						Data: metricdata.Histogram[int64]{
+							DataPoints: []metricdata.HistogramDataPoint[int64]{
 								{
 									Attributes: attribute.NewSet(
 										semconv.NetPeerNameKey.String(host),
@@ -348,8 +349,8 @@ func TestStreamingMetricsClient(t *testing.T) {
 									),
 									Count: 1,
 									Sum:   1,
-									Min:   metricdata.NewExtrema(1),
-									Max:   metricdata.NewExtrema(1),
+									Min:   metricdata.NewExtrema(int64(1)),
+									Max:   metricdata.NewExtrema(int64(1)),
 								},
 							},
 							Temporality: metricdata.CumulativeTemporality,
@@ -358,8 +359,8 @@ func TestStreamingMetricsClient(t *testing.T) {
 					{
 						Name: rpcClientResponsesPerRPC,
 						Unit: unitDimensionless,
-						Data: metricdata.Histogram{
-							DataPoints: []metricdata.HistogramDataPoint{
+						Data: metricdata.Histogram[int64]{
+							DataPoints: []metricdata.HistogramDataPoint[int64]{
 								{
 									Attributes: attribute.NewSet(
 										semconv.NetPeerNameKey.String(host),
@@ -370,8 +371,8 @@ func TestStreamingMetricsClient(t *testing.T) {
 									),
 									Count: 1,
 									Sum:   1,
-									Min:   metricdata.NewExtrema(1),
-									Max:   metricdata.NewExtrema(1),
+									Min:   metricdata.NewExtrema(int64(1)),
+									Max:   metricdata.NewExtrema(int64(1)),
 								},
 							},
 							Temporality: metricdata.CumulativeTemporality,
@@ -432,9 +433,9 @@ func TestStreamingMetricsClientFail(t *testing.T) {
 				Metrics: []metricdata.Metrics{
 					{
 						Name: rpcClientDuration,
-						Unit: string("ms"),
-						Data: metricdata.Histogram{
-							DataPoints: []metricdata.HistogramDataPoint{
+						Unit: "ms",
+						Data: metricdata.Histogram[int64]{
+							DataPoints: []metricdata.HistogramDataPoint[int64]{
 								{
 									Attributes: attribute.NewSet(
 										semconv.NetPeerNameKey.String(host),
@@ -446,8 +447,8 @@ func TestStreamingMetricsClientFail(t *testing.T) {
 									),
 									Count: 1,
 									Sum:   1000.0,
-									Min:   metricdata.NewExtrema(1000),
-									Max:   metricdata.NewExtrema(1000),
+									Min:   metricdata.NewExtrema(int64(1000)),
+									Max:   metricdata.NewExtrema(int64(1000)),
 								},
 							},
 							Temporality: metricdata.CumulativeTemporality,
@@ -456,8 +457,8 @@ func TestStreamingMetricsClientFail(t *testing.T) {
 					{
 						Name: rpcClientRequestSize,
 						Unit: unitBytes,
-						Data: metricdata.Histogram{
-							DataPoints: []metricdata.HistogramDataPoint{
+						Data: metricdata.Histogram[int64]{
+							DataPoints: []metricdata.HistogramDataPoint[int64]{
 								{
 									Attributes: attribute.NewSet(
 										semconv.NetPeerNameKey.String(host),
@@ -468,8 +469,8 @@ func TestStreamingMetricsClientFail(t *testing.T) {
 									),
 									Count: 1,
 									Sum:   2.0,
-									Min:   metricdata.NewExtrema(2),
-									Max:   metricdata.NewExtrema(2),
+									Min:   metricdata.NewExtrema(int64(2)),
+									Max:   metricdata.NewExtrema(int64(2)),
 								},
 							},
 							Temporality: metricdata.CumulativeTemporality,
@@ -478,8 +479,8 @@ func TestStreamingMetricsClientFail(t *testing.T) {
 					{
 						Name: rpcClientResponseSize,
 						Unit: unitBytes,
-						Data: metricdata.Histogram{
-							DataPoints: []metricdata.HistogramDataPoint{
+						Data: metricdata.Histogram[int64]{
+							DataPoints: []metricdata.HistogramDataPoint[int64]{
 								{
 									Attributes: attribute.NewSet(
 										semconv.NetPeerNameKey.String(host),
@@ -490,8 +491,8 @@ func TestStreamingMetricsClientFail(t *testing.T) {
 									),
 									Count: 2,
 									Sum:   4.0,
-									Min:   metricdata.NewExtrema(2),
-									Max:   metricdata.NewExtrema(2),
+									Min:   metricdata.NewExtrema(int64(2)),
+									Max:   metricdata.NewExtrema(int64(2)),
 								},
 								{
 									Attributes: attribute.NewSet(
@@ -504,8 +505,8 @@ func TestStreamingMetricsClientFail(t *testing.T) {
 									),
 									Count: 1,
 									Sum:   0.0,
-									Min:   metricdata.NewExtrema(0),
-									Max:   metricdata.NewExtrema(0),
+									Min:   metricdata.NewExtrema(int64(0)),
+									Max:   metricdata.NewExtrema(int64(0)),
 								},
 							},
 							Temporality: metricdata.CumulativeTemporality,
@@ -514,8 +515,8 @@ func TestStreamingMetricsClientFail(t *testing.T) {
 					{
 						Name: rpcClientRequestsPerRPC,
 						Unit: unitDimensionless,
-						Data: metricdata.Histogram{
-							DataPoints: []metricdata.HistogramDataPoint{
+						Data: metricdata.Histogram[int64]{
+							DataPoints: []metricdata.HistogramDataPoint[int64]{
 								{
 									Attributes: attribute.NewSet(
 										semconv.NetPeerNameKey.String(host),
@@ -526,8 +527,8 @@ func TestStreamingMetricsClientFail(t *testing.T) {
 									),
 									Count: 1,
 									Sum:   1,
-									Min:   metricdata.NewExtrema(1),
-									Max:   metricdata.NewExtrema(1),
+									Min:   metricdata.NewExtrema(int64(1)),
+									Max:   metricdata.NewExtrema(int64(1)),
 								},
 							},
 							Temporality: metricdata.CumulativeTemporality,
@@ -536,8 +537,8 @@ func TestStreamingMetricsClientFail(t *testing.T) {
 					{
 						Name: rpcClientResponsesPerRPC,
 						Unit: unitDimensionless,
-						Data: metricdata.Histogram{
-							DataPoints: []metricdata.HistogramDataPoint{
+						Data: metricdata.Histogram[int64]{
+							DataPoints: []metricdata.HistogramDataPoint[int64]{
 								{
 									Attributes: attribute.NewSet(
 										semconv.NetPeerNameKey.String(host),
@@ -548,8 +549,8 @@ func TestStreamingMetricsClientFail(t *testing.T) {
 									),
 									Count: 2,
 									Sum:   2,
-									Min:   metricdata.NewExtrema(1),
-									Max:   metricdata.NewExtrema(1),
+									Min:   metricdata.NewExtrema(int64(1)),
+									Max:   metricdata.NewExtrema(int64(1)),
 								},
 								{
 									Attributes: attribute.NewSet(
@@ -562,8 +563,8 @@ func TestStreamingMetricsClientFail(t *testing.T) {
 									),
 									Count: 1,
 									Sum:   1,
-									Min:   metricdata.NewExtrema(1),
-									Max:   metricdata.NewExtrema(1),
+									Min:   metricdata.NewExtrema(int64(1)),
+									Max:   metricdata.NewExtrema(int64(1)),
 								},
 							},
 							Temporality: metricdata.CumulativeTemporality,
@@ -624,8 +625,8 @@ func TestStreamingMetricsFail(t *testing.T) {
 					{
 						Name: rpcServerDuration,
 						Unit: unitMilliseconds,
-						Data: metricdata.Histogram{
-							DataPoints: []metricdata.HistogramDataPoint{
+						Data: metricdata.Histogram[int64]{
+							DataPoints: []metricdata.HistogramDataPoint[int64]{
 								{
 									Attributes: attribute.NewSet(
 										semconv.NetPeerNameKey.String(host),
@@ -637,8 +638,8 @@ func TestStreamingMetricsFail(t *testing.T) {
 									),
 									Count: 1,
 									Sum:   1000.0,
-									Min:   metricdata.NewExtrema(1000),
-									Max:   metricdata.NewExtrema(1000),
+									Min:   metricdata.NewExtrema(int64(1000)),
+									Max:   metricdata.NewExtrema(int64(1000)),
 								},
 							},
 							Temporality: metricdata.CumulativeTemporality,
@@ -647,8 +648,8 @@ func TestStreamingMetricsFail(t *testing.T) {
 					{
 						Name: rpcServerRequestSize,
 						Unit: unitBytes,
-						Data: metricdata.Histogram{
-							DataPoints: []metricdata.HistogramDataPoint{
+						Data: metricdata.Histogram[int64]{
+							DataPoints: []metricdata.HistogramDataPoint[int64]{
 								{
 									Attributes: attribute.NewSet(
 										semconv.NetPeerNameKey.String(host),
@@ -659,8 +660,8 @@ func TestStreamingMetricsFail(t *testing.T) {
 									),
 									Count: 1,
 									Sum:   2.0,
-									Min:   metricdata.NewExtrema(2),
-									Max:   metricdata.NewExtrema(2),
+									Min:   metricdata.NewExtrema(int64(2)),
+									Max:   metricdata.NewExtrema(int64(2)),
 								},
 							},
 							Temporality: metricdata.CumulativeTemporality,
@@ -669,8 +670,8 @@ func TestStreamingMetricsFail(t *testing.T) {
 					{
 						Name: rpcServerResponseSize,
 						Unit: unitBytes,
-						Data: metricdata.Histogram{
-							DataPoints: []metricdata.HistogramDataPoint{
+						Data: metricdata.Histogram[int64]{
+							DataPoints: []metricdata.HistogramDataPoint[int64]{
 								{
 									Attributes: attribute.NewSet(
 										semconv.NetPeerNameKey.String(host),
@@ -681,8 +682,8 @@ func TestStreamingMetricsFail(t *testing.T) {
 									),
 									Count: 2,
 									Sum:   4.0,
-									Min:   metricdata.NewExtrema(2),
-									Max:   metricdata.NewExtrema(2),
+									Min:   metricdata.NewExtrema(int64(2)),
+									Max:   metricdata.NewExtrema(int64(2)),
 								},
 							},
 							Temporality: metricdata.CumulativeTemporality,
@@ -691,8 +692,8 @@ func TestStreamingMetricsFail(t *testing.T) {
 					{
 						Name: rpcServerRequestsPerRPC,
 						Unit: unitDimensionless,
-						Data: metricdata.Histogram{
-							DataPoints: []metricdata.HistogramDataPoint{
+						Data: metricdata.Histogram[int64]{
+							DataPoints: []metricdata.HistogramDataPoint[int64]{
 								{
 									Attributes: attribute.NewSet(
 										semconv.NetPeerNameKey.String(host),
@@ -703,8 +704,8 @@ func TestStreamingMetricsFail(t *testing.T) {
 									),
 									Count: 1,
 									Sum:   1,
-									Min:   metricdata.NewExtrema(1),
-									Max:   metricdata.NewExtrema(1),
+									Min:   metricdata.NewExtrema(int64(1)),
+									Max:   metricdata.NewExtrema(int64(1)),
 								},
 							},
 							Temporality: metricdata.CumulativeTemporality,
@@ -713,8 +714,8 @@ func TestStreamingMetricsFail(t *testing.T) {
 					{
 						Name: rpcServerResponsesPerRPC,
 						Unit: unitDimensionless,
-						Data: metricdata.Histogram{
-							DataPoints: []metricdata.HistogramDataPoint{
+						Data: metricdata.Histogram[int64]{
+							DataPoints: []metricdata.HistogramDataPoint[int64]{
 								{
 									Attributes: attribute.NewSet(
 										semconv.NetPeerNameKey.String(host),
@@ -725,8 +726,8 @@ func TestStreamingMetricsFail(t *testing.T) {
 									),
 									Count: 2,
 									Sum:   2,
-									Min:   metricdata.NewExtrema(1),
-									Max:   metricdata.NewExtrema(1),
+									Min:   metricdata.NewExtrema(int64(1)),
+									Max:   metricdata.NewExtrema(int64(1)),
 								},
 							},
 							Temporality: metricdata.CumulativeTemporality,
@@ -776,8 +777,8 @@ func TestMetrics(t *testing.T) {
 					{
 						Name: rpcClientDuration,
 						Unit: unitMilliseconds,
-						Data: metricdata.Histogram{
-							DataPoints: []metricdata.HistogramDataPoint{
+						Data: metricdata.Histogram[float64]{
+							DataPoints: []metricdata.HistogramDataPoint[float64]{
 								{
 									Attributes: attribute.NewSet(
 										semconv.NetPeerNameKey.String(host),
@@ -788,8 +789,8 @@ func TestMetrics(t *testing.T) {
 									),
 									Count: 1,
 									Sum:   float64(time.Second.Milliseconds()),
-									Min:   metricdata.NewExtrema(1000),
-									Max:   metricdata.NewExtrema(1000),
+									Min:   metricdata.NewExtrema(float64(1000)),
+									Max:   metricdata.NewExtrema(float64(1000)),
 								},
 							},
 							Temporality: metricdata.CumulativeTemporality,
@@ -798,8 +799,8 @@ func TestMetrics(t *testing.T) {
 					{
 						Name: rpcClientRequestSize,
 						Unit: unitBytes,
-						Data: metricdata.Histogram{
-							DataPoints: []metricdata.HistogramDataPoint{
+						Data: metricdata.Histogram[int64]{
+							DataPoints: []metricdata.HistogramDataPoint[int64]{
 								{
 									Attributes: attribute.NewSet(
 										semconv.NetPeerNameKey.String(host),
@@ -810,8 +811,8 @@ func TestMetrics(t *testing.T) {
 									),
 									Count: 1,
 									Sum:   16,
-									Min:   metricdata.NewExtrema(16),
-									Max:   metricdata.NewExtrema(16),
+									Min:   metricdata.NewExtrema(int64(16)),
+									Max:   metricdata.NewExtrema(int64(16)),
 								},
 							},
 							Temporality: metricdata.CumulativeTemporality,
@@ -820,8 +821,8 @@ func TestMetrics(t *testing.T) {
 					{
 						Name: rpcClientResponseSize,
 						Unit: unitBytes,
-						Data: metricdata.Histogram{
-							DataPoints: []metricdata.HistogramDataPoint{
+						Data: metricdata.Histogram[int64]{
+							DataPoints: []metricdata.HistogramDataPoint[int64]{
 								{
 									Attributes: attribute.NewSet(
 										semconv.NetPeerNameKey.String(host),
@@ -832,8 +833,8 @@ func TestMetrics(t *testing.T) {
 									),
 									Count: 1,
 									Sum:   16,
-									Min:   metricdata.NewExtrema(16),
-									Max:   metricdata.NewExtrema(16),
+									Min:   metricdata.NewExtrema(int64(16)),
+									Max:   metricdata.NewExtrema(int64(16)),
 								},
 							},
 							Temporality: metricdata.CumulativeTemporality,
@@ -842,8 +843,8 @@ func TestMetrics(t *testing.T) {
 					{
 						Name: rpcClientRequestsPerRPC,
 						Unit: unitDimensionless,
-						Data: metricdata.Histogram{
-							DataPoints: []metricdata.HistogramDataPoint{
+						Data: metricdata.Histogram[int64]{
+							DataPoints: []metricdata.HistogramDataPoint[int64]{
 								{
 									Attributes: attribute.NewSet(
 										semconv.NetPeerNameKey.String(host),
@@ -854,8 +855,8 @@ func TestMetrics(t *testing.T) {
 									),
 									Count: 1,
 									Sum:   1,
-									Min:   metricdata.NewExtrema(1),
-									Max:   metricdata.NewExtrema(1),
+									Min:   metricdata.NewExtrema(int64(1)),
+									Max:   metricdata.NewExtrema(int64(1)),
 								},
 							},
 							Temporality: metricdata.CumulativeTemporality,
@@ -864,8 +865,8 @@ func TestMetrics(t *testing.T) {
 					{
 						Name: rpcClientResponsesPerRPC,
 						Unit: unitDimensionless,
-						Data: metricdata.Histogram{
-							DataPoints: []metricdata.HistogramDataPoint{
+						Data: metricdata.Histogram[int64]{
+							DataPoints: []metricdata.HistogramDataPoint[int64]{
 								{
 									Attributes: attribute.NewSet(
 										semconv.NetPeerNameKey.String(host),
@@ -876,8 +877,8 @@ func TestMetrics(t *testing.T) {
 									),
 									Count: 1,
 									Sum:   1,
-									Min:   metricdata.NewExtrema(1),
-									Max:   metricdata.NewExtrema(1),
+									Min:   metricdata.NewExtrema(int64(1)),
+									Max:   metricdata.NewExtrema(int64(1)),
 								},
 							},
 							Temporality: metricdata.CumulativeTemporality,
@@ -1947,18 +1948,18 @@ func cmpOpts() []cmp.Option {
 			})
 			return setx.Equals(&sety)
 		}),
-		cmp.Comparer(func(extx, exty metricdata.Extrema) bool {
+		cmp.Comparer(func(extx, exty metricdata.Extrema[int64]) bool {
 			valx, definedx := extx.Value()
 			valy, definedy := exty.Value()
 			return valx == valy && definedx == definedy
 		}),
-		cmpopts.SortSlices(func(x, y metricdata.HistogramDataPoint) bool {
+		cmpopts.SortSlices(func(x, y metricdata.HistogramDataPoint[int64]) bool {
 			return x.Attributes.Len() > y.Attributes.Len()
 		}),
-		cmpopts.IgnoreFields(metricdata.HistogramDataPoint{}, "StartTime"),
-		cmpopts.IgnoreFields(metricdata.HistogramDataPoint{}, "Time"),
-		cmpopts.IgnoreFields(metricdata.HistogramDataPoint{}, "Bounds"),
-		cmpopts.IgnoreFields(metricdata.HistogramDataPoint{}, "BucketCounts"),
+		cmpopts.IgnoreFields(metricdata.HistogramDataPoint[int64]{}, "StartTime"),
+		cmpopts.IgnoreFields(metricdata.HistogramDataPoint[int64]{}, "Time"),
+		cmpopts.IgnoreFields(metricdata.HistogramDataPoint[int64]{}, "Bounds"),
+		cmpopts.IgnoreFields(metricdata.HistogramDataPoint[int64]{}, "BucketCounts"),
 	}
 }
 

--- a/option.go
+++ b/option.go
@@ -20,6 +20,7 @@ import (
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/metric/noop"
 	"go.opentelemetry.io/otel/propagation"
 	semconv "go.opentelemetry.io/otel/semconv/v1.12.0"
 	"go.opentelemetry.io/otel/trace"
@@ -64,7 +65,7 @@ func WithoutTracing() Option {
 
 // WithoutMetrics disables metrics.
 func WithoutMetrics() Option {
-	return WithMeterProvider(metric.NewNoopMeterProvider())
+	return WithMeterProvider(noop.NewMeterProvider())
 }
 
 // WithAttributeFilter sets the attribute filter for all metrics and trace attributes.


### PR DESCRIPTION
The upstream opentelemetry SDK recently releases with some minor breaking changes and deprecation. Bumping the dependencies.