### PR TITLE
Add import aliases for packages whose name doesn't match

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,6 +16,13 @@ linters-settings:
       - '^print$'
       - '^println$'
       - '^panic$'
+  importas:
+    no-unaliased: true
+    alias:
+      - pkg: github.com/bufbuild/connect-go
+        alias: connect
+      - pkg: github.com/bufbuild/connect-opentelemetry-go/internal/gen/observability/ping/v1
+        alias: pingv1
   godox:
     # TODO, OPT, etc. comments are fine to commit. Use FIXME comments for
     # temporary hacks, and use godox to prevent committing them.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/bufbuild/connect-go"
+	connect "github.com/bufbuild/connect-go"
 	otelconnect "github.com/bufbuild/connect-opentelemetry-go"
 	// Generated from your protobuf schema by protoc-gen-go and
 	// protoc-gen-connect-go.

--- a/attributes.go
+++ b/attributes.go
@@ -21,7 +21,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/bufbuild/connect-go"
+	connect "github.com/bufbuild/connect-go"
 	"go.opentelemetry.io/otel/attribute"
 	semconv "go.opentelemetry.io/otel/semconv/v1.12.0"
 )

--- a/bench_test.go
+++ b/bench_test.go
@@ -21,7 +21,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/bufbuild/connect-go"
+	connect "github.com/bufbuild/connect-go"
 	pingv1 "github.com/bufbuild/connect-opentelemetry-go/internal/gen/observability/ping/v1"
 	"github.com/bufbuild/connect-opentelemetry-go/internal/gen/observability/ping/v1/pingv1connect"
 )

--- a/interceptor.go
+++ b/interceptor.go
@@ -21,7 +21,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/bufbuild/connect-go"
+	connect "github.com/bufbuild/connect-go"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/metric"

--- a/interceptor_test.go
+++ b/interceptor_test.go
@@ -25,7 +25,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/bufbuild/connect-go"
+	connect "github.com/bufbuild/connect-go"
 	pingv1 "github.com/bufbuild/connect-opentelemetry-go/internal/gen/observability/ping/v1"
 	"github.com/bufbuild/connect-opentelemetry-go/internal/gen/observability/ping/v1/pingv1connect"
 	"github.com/google/go-cmp/cmp"

--- a/otelconnect.go
+++ b/otelconnect.go
@@ -19,7 +19,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/bufbuild/connect-go"
+	connect "github.com/bufbuild/connect-go"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"

--- a/payloadinterceptor.go
+++ b/payloadinterceptor.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/bufbuild/connect-go"
+	connect "github.com/bufbuild/connect-go"
 )
 
 type streamingClientInterceptor struct {

--- a/pingserver_test.go
+++ b/pingserver_test.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/bufbuild/connect-go"
+	connect "github.com/bufbuild/connect-go"
 	pingv1 "github.com/bufbuild/connect-opentelemetry-go/internal/gen/observability/ping/v1"
 	"github.com/bufbuild/connect-opentelemetry-go/internal/gen/observability/ping/v1/pingv1connect"
 )


### PR DESCRIPTION
Add `connect` and `pingv1` import aliases for packages whose name doesn't match.

similar https://github.com/bufbuild/knit-go/pull/22