### PR TITLE
Alternate implementation for issue #92

### DIFF
--- a/option.go
+++ b/option.go
@@ -114,6 +114,41 @@ func WithTraceResponseHeader(keys ...string) Option {
 	}
 }
 
+// Event type that can be recorded, see WithMessageEvents.
+type Event int
+
+// Different types of events that can be recorded, see WithMessageEvents.
+const (
+	ReceivedEvents Event = iota
+	SentEvents
+)
+
+func (m messageEventsProviderOption) apply(c *config) {
+	for _, e := range m.events {
+		switch e {
+		case ReceivedEvents:
+			c.receivedEvent = true
+		case SentEvents:
+			c.sentEvent = true
+		}
+	}
+}
+
+type messageEventsProviderOption struct {
+	events []Event
+}
+
+// WithMessageEvents configures the Handler to record the specified events
+// (span.AddEvent) on spans. By default only summary attributes are added at the
+// end of the request.
+//
+// Valid events are:
+//   - ReceivedEvents: Record the number of bytes read after every gRPC read operation.
+//   - SentEvents: Record the number of bytes written after every gRPC write operation.
+func WithMessageEvents(events ...Event) Option {
+	return messageEventsProviderOption{events: events}
+}
+
 type attributeFilterOption struct {
 	filterAttribute AttributeFilter
 }

--- a/otelconnect.go
+++ b/otelconnect.go
@@ -55,4 +55,6 @@ type config struct {
 	trustRemote        bool
 	requestHeaderKeys  []string
 	responseHeaderKeys []string
+	receivedEvent      bool
+	sentEvent          bool
 }


### PR DESCRIPTION
Fixes #92 

This implementation more closely mirrors the default otelgrpc implementation in opentelemnetry-contrib

By default that implementation does *not* send events unless they are requested as part of the config.  

Much of this work is merely copying and adjusting some of the upstream implementation.