### PR TITLE
Handle "not modified" errors properly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ $(BIN)/license-header: Makefile
 
 $(BIN)/golangci-lint: Makefile
 	@mkdir -p $(@D)
-	GOBIN=$(abspath $(@D)) $(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.50.0
+	GOBIN=$(abspath $(@D)) $(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.0
 
 $(BIN)/protoc-gen-go: Makefile
 	@mkdir -p $(@D)

--- a/attributes.go
+++ b/attributes.go
@@ -97,6 +97,13 @@ func addressAttributes(address string) []attribute.KeyValue {
 }
 
 func statusCodeAttribute(protocol string, serverErr error) (attribute.KeyValue, bool) {
+	if connect.IsNotModifiedError(serverErr) {
+		// A "not modified" error is special: it's code is technically "unknown" but
+		// it would be misleading to label it as an unknown error since it's not really
+		// an error, but rather a sentinel to trigger a "304 Not Modified" HTTP status.
+		codeKey := attribute.Key("http.response.status_code")
+		return codeKey.Int(http.StatusNotModified), true
+	}
 	// Following the respective specifications, use integers and "status_code" for
 	// gRPC codes in contrast to strings and "error_code" for Connect codes.
 	switch protocol {

--- a/attributes.go
+++ b/attributes.go
@@ -97,13 +97,6 @@ func addressAttributes(address string) []attribute.KeyValue {
 }
 
 func statusCodeAttribute(protocol string, serverErr error) (attribute.KeyValue, bool) {
-	if connect.IsNotModifiedError(serverErr) {
-		// A "not modified" error is special: it's code is technically "unknown" but
-		// it would be misleading to label it as an unknown error since it's not really
-		// an error, but rather a sentinel to trigger a "304 Not Modified" HTTP status.
-		codeKey := attribute.Key("http.response.status_code")
-		return codeKey.Int(http.StatusNotModified), true
-	}
 	// Following the respective specifications, use integers and "status_code" for
 	// gRPC codes in contrast to strings and "error_code" for Connect codes.
 	switch protocol {
@@ -114,6 +107,12 @@ func statusCodeAttribute(protocol string, serverErr error) (attribute.KeyValue, 
 		}
 		return codeKey.Int64(0), true // gRPC uses 0 for success
 	case connectProtocol:
+		if connect.IsNotModifiedError(serverErr) {
+			// A "not modified" error is special: it's code is technically "unknown" but
+			// it would be misleading to label it as an unknown error since it's not really
+			// an error, but rather a sentinel to trigger a "304 Not Modified" HTTP status.
+			return semconv.HTTPStatusCodeKey.Int(http.StatusNotModified), true
+		}
 		codeKey := attribute.Key("rpc." + protocol + ".error_code")
 		if serverErr != nil {
 			return codeKey.String(connect.CodeOf(serverErr).String()), true


### PR DESCRIPTION
A "not modified" error really should _not_ be counted as an error with "Unknown" error code. So this addresses that.

That does beg the question: how _should_ it be handled? I see three options:
1. Skip the status code attribute entirely, since "not modified" doesn't cleanly map to an RPC code.
2. Treat it as "okay"/zero, since it's not really an error condition.
3. Don't use an RPC status code and instead use an HTTP status code attribute.

This PR currently uses the last option. But I'm happy to change it, based on what a larger group of minds thinks is the best way to label this state.