### PR TITLE
Make option to omit trace events apply to streaming RPCs

### DIFF
--- a/interceptor.go
+++ b/interceptor.go
@@ -133,7 +133,7 @@ func (i *Interceptor) WrapUnary(next connect.UnaryFunc) connect.UnaryFunc {
 				requestSize = proto.Size(msg)
 			}
 		}
-		if !i.config.omitRPCEvents {
+		if !i.config.omitTraceEvents {
 			span.AddEvent(messageKey,
 				trace.WithAttributes(
 					requestSpan,
@@ -153,7 +153,7 @@ func (i *Interceptor) WrapUnary(next connect.UnaryFunc) connect.UnaryFunc {
 			}
 			span.SetAttributes(headerAttributes(protocol, responseKey, response.Header(), i.config.responseHeaderKeys)...)
 		}
-		if !i.config.omitRPCEvents {
+		if !i.config.omitTraceEvents {
 			span.AddEvent(messageKey,
 				trace.WithAttributes(
 					responseSpan,
@@ -201,7 +201,7 @@ func (i *Interceptor) WrapStreamingClient(next connect.StreamingClientFunc) conn
 		state := newStreamingState(
 			req,
 			i.config.filterAttribute,
-			i.config.omitRPCEvents,
+			i.config.omitTraceEvents,
 			requestAttributes(req),
 			instrumentation.responseSize,
 			instrumentation.responsesPerRPC,
@@ -278,7 +278,7 @@ func (i *Interceptor) WrapStreamingHandler(next connect.StreamingHandlerFunc) co
 		state := newStreamingState(
 			req,
 			i.config.filterAttribute,
-			i.config.omitRPCEvents,
+			i.config.omitTraceEvents,
 			requestAttributes(req),
 			instrumentation.requestSize,
 			instrumentation.requestsPerRPC,

--- a/interceptor.go
+++ b/interceptor.go
@@ -133,7 +133,6 @@ func (i *Interceptor) WrapUnary(next connect.UnaryFunc) connect.UnaryFunc {
 				requestSize = proto.Size(msg)
 			}
 		}
-
 		if !i.config.omitRPCEvents {
 			span.AddEvent(messageKey,
 				trace.WithAttributes(
@@ -143,7 +142,6 @@ func (i *Interceptor) WrapUnary(next connect.UnaryFunc) connect.UnaryFunc {
 				),
 			)
 		}
-
 		response, err := next(ctx, request)
 		if statusCode, ok := statusCodeAttribute(protocol, err); ok {
 			attributes = append(attributes, statusCode)
@@ -155,7 +153,6 @@ func (i *Interceptor) WrapUnary(next connect.UnaryFunc) connect.UnaryFunc {
 			}
 			span.SetAttributes(headerAttributes(protocol, responseKey, response.Header(), i.config.responseHeaderKeys)...)
 		}
-
 		if !i.config.omitRPCEvents {
 			span.AddEvent(messageKey,
 				trace.WithAttributes(
@@ -165,7 +162,6 @@ func (i *Interceptor) WrapUnary(next connect.UnaryFunc) connect.UnaryFunc {
 				),
 			)
 		}
-
 		attributes = attributeFilter(req, attributes...)
 		span.SetStatus(spanStatus(err))
 		span.SetAttributes(attributes...)
@@ -205,6 +201,7 @@ func (i *Interceptor) WrapStreamingClient(next connect.StreamingClientFunc) conn
 		state := newStreamingState(
 			req,
 			i.config.filterAttribute,
+			i.config.omitRPCEvents,
 			requestAttributes(req),
 			instrumentation.responseSize,
 			instrumentation.responsesPerRPC,
@@ -281,6 +278,7 @@ func (i *Interceptor) WrapStreamingHandler(next connect.StreamingHandlerFunc) co
 		state := newStreamingState(
 			req,
 			i.config.filterAttribute,
+			i.config.omitRPCEvents,
 			requestAttributes(req),
 			instrumentation.requestSize,
 			instrumentation.requestsPerRPC,

--- a/option.go
+++ b/option.go
@@ -73,8 +73,11 @@ func WithAttributeFilter(filter AttributeFilter) Option {
 	return &attributeFilterOption{filterAttribute: filter}
 }
 
-// WithoutServerPeerAttributes removes net.peer.port and net.peer.name attributes from server trace and span attributes.
-// This is recommended to use as net.peer server attributes have high cardinality.
+// WithoutServerPeerAttributes removes net.peer.port and net.peer.name
+// attributes from server trace and span attributes. The default behavior
+// follows the OpenTelemetry semantic conventions for RPC, but produces very
+// high-cardinality data; this option significantly reduces cardinality in most
+// environments.
 func WithoutServerPeerAttributes() Option {
 	return WithAttributeFilter(func(request *Request, value attribute.KeyValue) bool {
 		if request.Spec.IsClient {
@@ -114,7 +117,9 @@ func WithTraceResponseHeader(keys ...string) Option {
 	}
 }
 
-// WithoutTraceEvents disables trace events for both unary and streaming interceptors.
+// WithoutTraceEvents disables trace events for both unary and streaming
+// interceptors. This reduces the quantity of data sent to your tracing system
+// by omitting per-message information like message size.
 func WithoutTraceEvents() Option {
 	return &omitTraceEventsOption{}
 }

--- a/option.go
+++ b/option.go
@@ -114,8 +114,8 @@ func WithTraceResponseHeader(keys ...string) Option {
 	}
 }
 
-func WithoutRPCEvents() Option {
-	return &omitRPCEventsOption{}
+func WithoutTraceEvents() Option {
+	return &omitTraceEventsOption{}
 }
 
 type attributeFilterOption struct {
@@ -198,8 +198,8 @@ func (o *traceResponseHeaderOption) apply(c *config) {
 	}
 }
 
-type omitRPCEventsOption struct{}
+type omitTraceEventsOption struct{}
 
-func (o *omitRPCEventsOption) apply(c *config) {
-	c.omitRPCEvents = true
+func (o *omitTraceEventsOption) apply(c *config) {
+	c.omitTraceEvents = true
 }

--- a/option.go
+++ b/option.go
@@ -114,6 +114,7 @@ func WithTraceResponseHeader(keys ...string) Option {
 	}
 }
 
+// WithoutTraceEvents disables trace events for both unary and streaming interceptors.
 func WithoutTraceEvents() Option {
 	return &omitTraceEventsOption{}
 }

--- a/otelconnect.go
+++ b/otelconnect.go
@@ -55,5 +55,5 @@ type config struct {
 	trustRemote        bool
 	requestHeaderKeys  []string
 	responseHeaderKeys []string
-	omitRPCEvents      bool
+	omitTraceEvents    bool
 }

--- a/streaming.go
+++ b/streaming.go
@@ -32,7 +32,7 @@ type streamingState struct {
 	protocol        string
 	req             *Request
 	attributeFilter AttributeFilter
-	omitRPCEvents   bool
+	omitTraceEvents bool
 	attributes      []attribute.KeyValue
 	error           error
 	sentCounter     int
@@ -46,7 +46,7 @@ type streamingState struct {
 func newStreamingState(
 	req *Request,
 	attributeFilter AttributeFilter,
-	omitRPCEvents bool,
+	omitTraceEvents bool,
 	attributes []attribute.KeyValue,
 	receiveSize, receivesPerRPC, sendSize, sendsPerRPC metric.Int64Histogram,
 ) *streamingState {
@@ -54,7 +54,7 @@ func newStreamingState(
 	return &streamingState{
 		protocol:        protocolToSemConv(req.Peer.Protocol),
 		attributeFilter: attributeFilter,
-		omitRPCEvents:   omitRPCEvents,
+		omitTraceEvents: omitTraceEvents,
 		req:             req,
 		attributes:      attributes,
 		receiveSize:     receiveSize,
@@ -91,7 +91,7 @@ func (s *streamingState) receive(ctx context.Context, msg any, conn sendReceiver
 	protomsg, ok := msg.(proto.Message)
 	size := proto.Size(protomsg)
 	s.receivedCounter++
-	if !s.omitRPCEvents {
+	if !s.omitTraceEvents {
 		s.event(ctx, semconv.MessageTypeReceived, s.receivedCounter, ok, size)
 	}
 	s.receiveSize.Record(ctx, int64(size), metric.WithAttributes(s.attributes...))
@@ -117,7 +117,7 @@ func (s *streamingState) send(ctx context.Context, msg any, conn sendReceiver) e
 	protomsg, ok := msg.(proto.Message)
 	size := proto.Size(protomsg)
 	s.sentCounter++
-	if !s.omitRPCEvents {
+	if !s.omitTraceEvents {
 		s.event(ctx, semconv.MessageTypeSent, s.sentCounter, ok, size)
 	}
 	s.sendSize.Record(ctx, int64(size), metric.WithAttributes(s.attributes...))

--- a/streaming.go
+++ b/streaming.go
@@ -90,8 +90,8 @@ func (s *streamingState) receive(ctx context.Context, msg any, conn sendReceiver
 	}
 	protomsg, ok := msg.(proto.Message)
 	size := proto.Size(protomsg)
-	s.receivedCounter++
 	if !s.omitTraceEvents {
+		s.receivedCounter++
 		s.event(ctx, semconv.MessageTypeReceived, s.receivedCounter, ok, size)
 	}
 	s.receiveSize.Record(ctx, int64(size), metric.WithAttributes(s.attributes...))
@@ -116,8 +116,8 @@ func (s *streamingState) send(ctx context.Context, msg any, conn sendReceiver) e
 	}
 	protomsg, ok := msg.(proto.Message)
 	size := proto.Size(protomsg)
-	s.sentCounter++
 	if !s.omitTraceEvents {
+		s.sentCounter++
 		s.event(ctx, semconv.MessageTypeSent, s.sentCounter, ok, size)
 	}
 	s.sendSize.Record(ctx, int64(size), metric.WithAttributes(s.attributes...))

--- a/streaming.go
+++ b/streaming.go
@@ -32,6 +32,7 @@ type streamingState struct {
 	protocol        string
 	req             *Request
 	attributeFilter AttributeFilter
+	omitRPCEvents   bool
 	attributes      []attribute.KeyValue
 	error           error
 	sentCounter     int
@@ -45,6 +46,7 @@ type streamingState struct {
 func newStreamingState(
 	req *Request,
 	attributeFilter AttributeFilter,
+	omitRPCEvents bool,
 	attributes []attribute.KeyValue,
 	receiveSize, receivesPerRPC, sendSize, sendsPerRPC metric.Int64Histogram,
 ) *streamingState {
@@ -52,6 +54,7 @@ func newStreamingState(
 	return &streamingState{
 		protocol:        protocolToSemConv(req.Peer.Protocol),
 		attributeFilter: attributeFilter,
+		omitRPCEvents:   omitRPCEvents,
 		req:             req,
 		attributes:      attributes,
 		receiveSize:     receiveSize,
@@ -88,7 +91,9 @@ func (s *streamingState) receive(ctx context.Context, msg any, conn sendReceiver
 	protomsg, ok := msg.(proto.Message)
 	size := proto.Size(protomsg)
 	s.receivedCounter++
-	s.event(ctx, semconv.MessageTypeReceived, s.receivedCounter, ok, size)
+	if !s.omitRPCEvents {
+		s.event(ctx, semconv.MessageTypeReceived, s.receivedCounter, ok, size)
+	}
 	s.receiveSize.Record(ctx, int64(size), metric.WithAttributes(s.attributes...))
 	s.receivesPerRPC.Record(ctx, 1, metric.WithAttributes(s.attributes...))
 	return err
@@ -112,7 +117,9 @@ func (s *streamingState) send(ctx context.Context, msg any, conn sendReceiver) e
 	protomsg, ok := msg.(proto.Message)
 	size := proto.Size(protomsg)
 	s.sentCounter++
-	s.event(ctx, semconv.MessageTypeSent, s.sentCounter, ok, size)
+	if !s.omitRPCEvents {
+		s.event(ctx, semconv.MessageTypeSent, s.sentCounter, ok, size)
+	}
 	s.sendSize.Record(ctx, int64(size), metric.WithAttributes(s.attributes...))
 	s.sendsPerRPC.Record(ctx, 1, metric.WithAttributes(s.attributes...))
 	return err


### PR DESCRIPTION
- Changes name of option from `OmitRPCEvents` to `OmitTraceEvents` to be more clear
- Omits trace events for streaming too
- Adds tests
Closes: #92 